### PR TITLE
Allow the `TextField` component to receive the full width property

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -40,11 +40,11 @@ const styles = theme => {
  * The TextField component basically re-exports the Material TextField
  * component, with a few tweaks.
  */
-const TextField = ({ classes, error, helperText, id, label, required, ...other }) => {
+const TextField = ({ classes, error, helperText, id, label, required, fullWidth, ...other }) => {
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined
 
   return (
-    <FormControl aria-describedby={helperTextId} error={error}>
+    <FormControl aria-describedby={helperTextId} error={error} fullWidth={fullWidth}>
       {label && (
         <FormLabel htmlFor={id} required={required}>
           {label}

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -40,7 +40,16 @@ const styles = theme => {
  * The TextField component basically re-exports the Material TextField
  * component, with a few tweaks.
  */
-const TextField = ({ classes, error, helperText, id, label, required, fullWidth, ...other }) => {
+const TextField = ({
+  classes,
+  error,
+  fullWidth,
+  helperText,
+  id,
+  label,
+  required,
+  ...other
+}) => {
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined
 
   return (

--- a/src/TextField/stories.jsx
+++ b/src/TextField/stories.jsx
@@ -7,7 +7,7 @@ import { TextField, Grid, withStyles } from '../index';
 const spacing = 16
 
 const GridDecorator = story => (
-  <Grid container justify="center" spacing={spacing}>
+  <Grid container justify="left" spacing={spacing}>
     {story()}
   </Grid>
 )
@@ -27,6 +27,9 @@ storiesOf('Text Fields', module)
       </Grid>
       <Grid item>
         <TextField disabled helperText="Helper text" id="disabled" label="Disabled" onChange={action('change')} placeholder="Placeholder text" />
+      </Grid>
+      <Grid item xs={12}>
+        <TextField helperText="Helper text" id="default" label="Full width" onChange={action('change')} placeholder="Placeholder text" fullWidth />
       </Grid>
     </React.Fragment>
   ))


### PR DESCRIPTION
This PR allows the `TextField` component to pass the `fullWidth` property to its underlying `FormControl` component, allowing any text field to have a full width if desired.

This PR also proposes a left aligned grid container for `TextField` stories, as a centralized view in combination with the new full width example made the field group above the full width to never be aligned.

#### Screenshot

![image](https://user-images.githubusercontent.com/1538066/48809237-ec9d7c80-ed0a-11e8-96ef-f1f23f1dc2de.png)
