### PR TITLE
Add text field component documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Don't capitalise button text
 * Ensure form labels are left aligned
 * Add `Button` prop types
+* Add `TextField` prop types
 
 ## 1.6.0 (2018-11-28)
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "jest": "^23.6.0",
+    "lodash": "^4.17.11",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",

--- a/src/ComponentOverview.jsx
+++ b/src/ComponentOverview.jsx
@@ -1,5 +1,6 @@
 import Marked from 'storybook-readme/components/Marked'
 import React from 'react'
+import { get } from 'lodash'
 
 import { propDefinitions } from './util'
 
@@ -41,7 +42,7 @@ const PropDefinitionsTable = ({ propDefinitions }) => {
 const ComponentOverview = ({ component }) => (
   <div className='markdown-body'>
     <h1>Overview</h1>
-    <Marked md={component.__docgenInfo.description} />
+    <Marked md={get(component, '__docgenInfo.description', '')} />
     <h2>Props</h2>
     <PropDefinitionsTable propDefinitions={propDefinitions(component)} />
   </div>

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -1,6 +1,7 @@
 import FormControl from '@material-ui/core/FormControl'
 import FormHelperText from '@material-ui/core/FormHelperText'
 import InputBase from '@material-ui/core/InputBase'
+import PropTypes from 'prop-types'
 import React from 'react'
 
 import FormLabel from '../form/FormLabel'
@@ -37,10 +38,20 @@ const styles = theme => {
 }
 
 /**
- * The TextField component basically re-exports the Material TextField
- * component, with a few tweaks.
+ * The `<TextField>` component allows users to enter and edit text.
+ *
+ * ```js
+  * import { TextField } from '@theconversation/ui'
+  *
+ * <TextField
+ *   helperText="Enter your full name"
+ *   label="Name"
+ *   onChange={alert("change")}
+ *   placeholder="Jane Doe"
+ * />
+ * ```
  */
-const TextField = ({
+export const TextField = ({
   disabled,
   error,
   fullWidth,
@@ -67,6 +78,68 @@ const TextField = ({
       )}
     </FormControl>
   )
+}
+
+TextField.propTypes = {
+  /**
+   * A boolean value indicating whether the text field is disabled.
+   */
+  disabled: PropTypes.bool,
+
+  /**
+   * A boolean value indicating whether the text field is in an error state.
+   */
+  error: PropTypes.bool,
+
+  /**
+   * A boolean value indicating whether the text field should take up the full
+   * width of its container.
+   */
+  fullWidth: PropTypes.bool,
+
+  /**
+   * The text displayed below the text field.
+   */
+  helperText: PropTypes.string,
+
+  /**
+   * The `id` of the underlying `<input>` element.
+   */
+  id: PropTypes.string,
+
+  /**
+   * The text displayed above the text field.
+   */
+  label: PropTypes.string,
+
+  /**
+   * The callback function called when the text field value changes.
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * The text displayed inside text field before the user enters a value.
+   */
+  placeholder: PropTypes.string,
+
+  /**
+   * A boolean value indicating whether the text field is required to be filled
+   * by the user.
+   */
+  required: PropTypes.bool,
+
+  /**
+   * The type of the text field.
+   */
+  type: PropTypes.oneOf(['text', 'password'])
+}
+
+TextField.defaultProps = {
+  disabled: false,
+  error: false,
+  fullWidth: false,
+  required: false,
+  type: 'text'
 }
 
 export default withStyles(styles)(TextField)

--- a/src/TextField/stories/index.jsx
+++ b/src/TextField/stories/index.jsx
@@ -1,0 +1,10 @@
+import { storiesOf } from '@storybook/react'
+
+import overview from './overview'
+import states from './states'
+import types from './types'
+
+storiesOf('Text Fields', module)
+  .add('Overview', overview)
+  .add('States', states)
+  .add('Types', types)

--- a/src/TextField/stories/overview.jsx
+++ b/src/TextField/stories/overview.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+import ComponentOverview from '../../ComponentOverview'
+import { TextField } from '../TextField'
+
+export default () => <ComponentOverview component={TextField} />

--- a/src/TextField/stories/states.jsx
+++ b/src/TextField/stories/states.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { withDocs } from 'storybook-readme'
+
+import TextField from '../TextField'
+import { item, grid } from '../../util'
+
+const md = `
+# States
+
+The \`<TextField>\` component has multiple states:
+
+* \`required\`: A text field which is required to be filled by the user.
+* \`disabled\`: A text field which is disabled.
+* \`error\`: A text field which is in an error state.
+
+You can set the state of a text field using one (or more) boolean flags:
+
+~~~js
+<TextField required />
+<TextField disabled />
+<TextField error />
+~~~
+
+## Example
+
+<!-- STORY -->
+`
+
+const textFields = [
+  <TextField
+    helperText='Helper text'
+    label='Default'
+    onChange={action('change')}
+    placeholder='Placeholder text'
+  />,
+  <TextField required
+    helperText='Helper text'
+    label='Required'
+    onChange={action('change')}
+    placeholder='Placeholder text'
+  />,
+  <TextField disabled
+    helperText='Helper text'
+    label='Disabled'
+    onChange={action('change')}
+    placeholder='Placeholder text'
+  />,
+  <TextField error
+    helperText='Helper text'
+    label='Error'
+    onChange={action('change')}
+    placeholder='Placeholder text'
+  />
+]
+
+export default withDocs(md, grid(
+  textFields.map(textField => item(() => textField))
+))

--- a/src/TextField/stories/types.jsx
+++ b/src/TextField/stories/types.jsx
@@ -1,82 +1,46 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import { storiesOf } from '@storybook/react'
+import { withDocs } from 'storybook-readme'
 
-import { TextField, Grid } from '../index'
+import TextField from '../TextField'
+import { item, grid } from '../../util'
 
-const spacing = 16
+const md = `
+# Types
 
-const GridDecorator = story => (
-  <Grid container justify='flex-start' spacing={spacing}>
-    {story()}
-  </Grid>
-)
+The \`<TextField>\` component has multiple types:
 
-storiesOf('Text Fields', module)
-  .addDecorator(GridDecorator)
-  .add('text', () => (
-    <React.Fragment>
-      <Grid item>
-        <TextField
-          helperText='Helper text'
-          id='default'
-          label='Default'
-          onChange={action('change')}
-          placeholder='Placeholder text'
-        />
-      </Grid>
-      <Grid item>
-        <TextField
-          helperText='Helper text'
-          id='required'
-          label='Required'
-          onChange={action('change')}
-          placeholder='Placeholder text'
-          required
-        />
-      </Grid>
-      <Grid item>
-        <TextField
-          error
-          helperText='Helper text'
-          id='error'
-          label='Error'
-          onChange={action('change')}
-          placeholder='Placeholder text'
-        />
-      </Grid>
-      <Grid item>
-        <TextField
-          disabled
-          helperText='Helper text'
-          id='disabled'
-          label='Disabled'
-          onChange={action('change')}
-          placeholder='Placeholder text'
-        />
-      </Grid>
-      <Grid item xs={12}>
-        <TextField
-          helperText='Helper text'
-          id='default'
-          label='Full width'
-          onChange={action('change')}
-          placeholder='Placeholder text'
-          fullWidth
-        />
-      </Grid>
-    </React.Fragment>
-  ))
-  .add('password', () => (
-    <React.Fragment>
-      <Grid item>
-        <TextField
-          helperText='Enter your secret password'
-          id='password'
-          label='Password'
-          onChange={action('change')}
-          type='password'
-        />
-      </Grid>
-    </React.Fragment>
-  ))
+* \`text\`: A regular text field (this is the default type).
+* \`password\`: A text field whose value is obscured.
+
+You can set the type of a text field using the \`type\` prop:
+
+~~~js
+<TextField type="text" />
+<TextField type="password" />
+~~~
+
+## Example
+
+<!-- STORY -->
+`
+
+const textFields = [
+  <TextField
+    helperText='Enter your full name'
+    label='Name'
+    onChange={action('change')}
+    placeholder='Jane Doe'
+    type='text'
+  />,
+  <TextField
+    helperText='Enter your secret password'
+    label='Password'
+    onChange={action('change')}
+    type='password'
+  />
+]
+
+export default withDocs(md, grid(
+  textFields.map(textField => item(() => textField))
+))

--- a/src/util.jsx
+++ b/src/util.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Grid } from './index'
+import { get } from 'lodash'
 
 const SPACING = 16
 
@@ -17,7 +18,7 @@ export const item = as => () => (
 
 export const propDefinitions = component =>
   Object
-    .keys(component.__docgenInfo.props)
+    .keys(get(component, '__docgenInfo.props', []))
     .sort()
     .reduce((result, property) => {
       const prop = component.__docgenInfo.props[property]


### PR DESCRIPTION
This PR adds documentation for the `<TextField>` component.

## How to test

* Run `make storybook`
* Open `localhost:9001` and check it out