### PR TITLE
Automatic external dependency configuration for rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3664,6 +3664,15 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "builtins": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-2.0.0.tgz",
+      "integrity": "sha512-8srrxpDx3a950BHYcbse+xMjupHHECvQYnShkoPz2ZLhTBrk/HQO6nWMh4o4ui8YYp2ourGVYXlGqFm+UYQwmA==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -12558,6 +12567,49 @@
         "@types/node": "*"
       }
     },
+    "rollup-plugin-auto-external": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-auto-external/-/rollup-plugin-auto-external-2.0.0.tgz",
+      "integrity": "sha512-HQM3ZkZYfSam1uoZtAB9sK26EiAsfs1phrkf91c/YX+S07wugyRXSigBxrIwiLr5EPPilKYmoMxsrnlGBsXnuQ==",
+      "dev": true,
+      "requires": {
+        "builtins": "^2.0.0",
+        "read-pkg": "^3.0.0",
+        "safe-resolve": "^1.0.0",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "rollup-plugin-babel": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.0.3.tgz",
@@ -12679,6 +12731,12 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-resolve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-resolve/-/safe-resolve-1.0.0.tgz",
+      "integrity": "sha1-/jT40p16O+z9JJ0KqKeZtcPPZVk=",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-dom": "^16.6.3",
     "react-jss": "^8.6.1",
     "rollup": "^0.67.3",
+    "rollup-plugin-auto-external": "^2.0.0",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-filesize": "^5.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,10 +2,12 @@ import babel from 'rollup-plugin-babel'
 import commonjs from 'rollup-plugin-commonjs'
 import filesize from 'rollup-plugin-filesize'
 import resolve from 'rollup-plugin-node-resolve'
+import autoExternal from 'rollup-plugin-auto-external'
 
 import pkg from './package.json'
 
 const plugins = [
+  autoExternal(),
   babel({ exclude: '**/node_modules/**' }),
   resolve({ extensions: ['.js', '.jsx'] }),
   commonjs(),
@@ -13,7 +15,6 @@ const plugins = [
 ]
 
 export default {
-  external: ['prop-types', 'react', 'react-dom'],
   input: 'src/index.js',
   output: [
     { file: pkg.main, format: 'cjs' },


### PR DESCRIPTION
Replaces our manually curated list, which was [causing hard to diagnose problems](https://github.com/conversation/tc/pull/8753) with a plugin that uses our `package.json` to automatically populate the list of external dependencies:

https://www.npmjs.com/package/rollup-plugin-auto-external

