### PR TITLE
Add script to package.json to run storybook locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "component",
     "ui"
   ],
+  "scripts": {
+    "storybook": "start-storybook -p 9001 -c .storybook"
+  },
   "main": "dist/ui.cjs.js",
   "module": "dist/ui.esm.js",
   "files": [


### PR DESCRIPTION
For another PR, I added this to the `package.json` as it's the usual way to run storybook, right?

I thought it might be handy for future us!