### PR TITLE
[RFC] Use Noto Sans font-family for body2

### DIFF
--- a/src/styles/themes/legacy.js
+++ b/src/styles/themes/legacy.js
@@ -25,9 +25,9 @@ export default memoize(() => createMuiTheme({
     },
 
     body2: {
-      fontFamily: 'Libre Baskerville',
       fontSize: '1rem',
       lineHeight: '1.5'
+      fontFamily: 'Noto Sans'
     },
 
     button: {

--- a/src/styles/themes/legacy.js
+++ b/src/styles/themes/legacy.js
@@ -25,8 +25,6 @@ export default memoize(() => createMuiTheme({
     },
 
     body2: {
-      fontSize: '1rem',
-      lineHeight: '1.5'
       fontFamily: 'Noto Sans'
     },
 


### PR DESCRIPTION
I've notice this before, but confirmed today with @ZoeJazz that the `body2` variant typography seemed "not quite fit" for its use cases. I confirmed with her that "Noto Sans" should be the font to be used on any type of "labeled information", while "Libre Baskerville" will be used for content reading due to being a serif font.

### Before

----

#### Switch

<img width="181" alt="image" src="https://user-images.githubusercontent.com/1538066/53387752-69ac5200-39dc-11e9-8e80-44a3d59dbb7b.png">

----

#### Typography Variants

<img width="198" alt="image" src="https://user-images.githubusercontent.com/1538066/53387764-7630aa80-39dc-11e9-9f28-6678065a2f6d.png">

### After

----

#### Switch

<img width="164" alt="image" src="https://user-images.githubusercontent.com/1538066/53387720-42ee1b80-39dc-11e9-9f87-f0cf9efc8ece.png">

----

#### Typography Variants

<img width="191" alt="image" src="https://user-images.githubusercontent.com/1538066/53387738-57caaf00-39dc-11e9-9a9e-e21a2eeeb38e.png">

