### PR TITLE
[TC-688] Add events to TextField and Dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Upgrade storybook to 5.x
+* Added `onBlur` and `onFocus` events to `TextField`
+* Added `onBlur` and `onFocus` events to `Dropdown`
 
 ## 1.11.0
 

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -149,6 +149,16 @@ Dropdown.propTypes = {
   onChange: PropTypes.func,
 
   /**
+   * The callback function called when the text field loses focus.
+   */
+  onBlur: PropTypes.func,
+
+  /**
+   * The callback function called when the text field gains focus.
+   */
+  onFocus: PropTypes.func,
+
+  /**
    * A boolean value indicating whether the dropdown is required to be filled
    * by the user.
    */

--- a/src/Dropdown/Dropdown.test.jsx
+++ b/src/Dropdown/Dropdown.test.jsx
@@ -2,7 +2,7 @@ import FormControl from '@material-ui/core/FormControl'
 import FormHelperText from '@material-ui/core/FormHelperText'
 import React from 'react'
 import Select from '@material-ui/core/Select'
-import { shallow } from 'enzyme'
+import { mount, shallow } from 'enzyme'
 
 import Dropdown from './Dropdown'
 import FormLabel from '../form/FormLabel'
@@ -80,6 +80,49 @@ describe('<Dropdown />', () => {
         </Dropdown>
       ).dive().find(FormHelperText)
       expect(wrapper.props().id).toBe('foo-helper-text')
+    })
+  })
+
+  describe('events', () => {
+    describe('when changed', () => {
+      it('calls the callback', () => {
+        const onChange = jest.fn()
+        const wrapper = mount(
+          <Dropdown value='' onChange={onChange}>
+            <MenuItem value='1'>one</MenuItem>
+            <MenuItem value='2'>two</MenuItem>
+          </Dropdown>
+        )
+        wrapper.find('[role="button"]').simulate('click')
+        wrapper.find(MenuItem).at(1).simulate('click')
+        expect(onChange).toHaveBeenCalled()
+      })
+    })
+
+    describe('when gains focus', () => {
+      it('calls the callback', () => {
+        const onFocus = jest.fn()
+        const wrapper = mount(
+          <Dropdown value='' onFocus={onFocus}>
+            <MenuItem value='1'>one</MenuItem>
+          </Dropdown>
+        )
+        wrapper.find('div[role="button"]').simulate('focus')
+        expect(onFocus).toHaveBeenCalled()
+      })
+    })
+
+    describe('when loses focus', () => {
+      it('calls the callback', () => {
+        const onBlur = jest.fn()
+        const wrapper = mount(
+          <Dropdown value='' onBlur={onBlur}>
+            <MenuItem value='1'>one</MenuItem>
+          </Dropdown>
+        )
+        wrapper.find('div[role="button"]').simulate('blur')
+        expect(onBlur).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/Dropdown/stories/events.jsx
+++ b/src/Dropdown/stories/events.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { withDocs } from 'storybook-readme'
+
+import { GridLayout } from '../../util'
+import { Dropdown, MenuItem } from '../../index'
+
+const md = `
+# States
+
+The \`<Dropdown>\` component accepts multiple events:
+
+* \`onChange\`: When the field's value changes
+* \`onBlur\`: When the field loses focus
+* \`onFocus\`: When the field gains focus
+
+~~~js
+<Dropdown onChange={alert('change')} />
+<Dropdown onBlur={alert('blur')} />
+<Dropdown onFocus={alert('focus')} />
+~~~
+
+## Example
+
+<!-- STORY -->
+`
+
+class ExampleDropdown extends React.Component {
+  state = {
+    value: '1'
+  }
+
+  render () {
+    return (
+      <Dropdown
+        value={this.state.value}
+        {...this.props}
+      >
+        <MenuItem value='1'>One</MenuItem>
+        <MenuItem value='2'>Two</MenuItem>
+        <MenuItem value='3'>Three</MenuItem>
+      </Dropdown>
+    )
+  }
+}
+
+export default withDocs(md, () =>
+  <GridLayout>
+    <ExampleDropdown
+      helperText='Trigger on change'
+      label='onChange'
+      onChange={action('change')}
+    />
+    <ExampleDropdown
+      helperText='Trigger on lose focus'
+      label='onBlur'
+      onBlur={action('blur')}
+    />
+    <ExampleDropdown
+      helperText='Trigger on gain focus'
+      label='onFocus'
+      onFocus={action('focus')}
+    />
+  </GridLayout>
+)

--- a/src/Dropdown/stories/events.jsx
+++ b/src/Dropdown/stories/events.jsx
@@ -47,18 +47,9 @@ class ExampleDropdown extends React.Component {
 export default withDocs(md, () =>
   <GridLayout>
     <ExampleDropdown
-      helperText='Trigger on change'
-      label='onChange'
+      helperText='Event triggers'
       onChange={action('change')}
-    />
-    <ExampleDropdown
-      helperText='Trigger on lose focus'
-      label='onBlur'
       onBlur={action('blur')}
-    />
-    <ExampleDropdown
-      helperText='Trigger on gain focus'
-      label='onFocus'
       onFocus={action('focus')}
     />
   </GridLayout>

--- a/src/Dropdown/stories/index.jsx
+++ b/src/Dropdown/stories/index.jsx
@@ -1,8 +1,10 @@
 import { storiesOf } from '@storybook/react'
 
 import overview from './overview'
+import events from './events'
 import states from './states'
 
 storiesOf('Dropdowns', module)
   .add('Overview', overview)
   .add('States', states)
+  .add('Events', events)

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -123,6 +123,16 @@ TextField.propTypes = {
   onChange: PropTypes.func,
 
   /**
+   * The callback function called when the text field loses focus.
+   */
+  onBlur: PropTypes.func,
+
+  /**
+   * The callback function called when the text field gains focus.
+   */
+  onFocus: PropTypes.func,
+
+  /**
    * The text displayed inside text field before the user enters a value.
    */
   placeholder: PropTypes.string,

--- a/src/TextField/TextField.test.jsx
+++ b/src/TextField/TextField.test.jsx
@@ -56,12 +56,32 @@ describe('<TextField />', () => {
     })
   })
 
-  describe('when changed', () => {
-    it('calls the callback', () => {
-      const onChange = jest.fn()
-      const wrapper = mount(<TextField onChange={onChange} />)
-      wrapper.find('input').simulate('change')
-      expect(onChange).toHaveBeenCalled()
+  describe('events', () => {
+    describe('when changed', () => {
+      it('calls the callback', () => {
+        const onChange = jest.fn()
+        const wrapper = mount(<TextField onChange={onChange} />)
+        wrapper.find('input').simulate('change')
+        expect(onChange).toHaveBeenCalled()
+      })
+    })
+
+    describe('when gains focus', () => {
+      it('calls the callback', () => {
+        const onFocus = jest.fn()
+        const wrapper = mount(<TextField onFocus={onFocus} />)
+        wrapper.find('input').simulate('focus')
+        expect(onFocus).toHaveBeenCalled()
+      })
+    })
+
+    describe('when loses focus', () => {
+      it('calls the callback', () => {
+        const onBlur = jest.fn()
+        const wrapper = mount(<TextField onBlur={onBlur} />)
+        wrapper.find('input').simulate('blur')
+        expect(onBlur).toHaveBeenCalled()
+      })
     })
   })
 })

--- a/src/TextField/stories/events.jsx
+++ b/src/TextField/stories/events.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { withDocs } from 'storybook-readme'
+
+import { GridLayout } from '../../util'
+import { TextField } from '../../index'
+
+const md = `
+# Events
+
+The \`<TextField>\` component accepts multiple events:
+
+* \`onChange\`: When the field's value changes
+* \`onBlur\`: When the field loses focus
+* \`onFocus\`: When the field gains focus
+
+~~~js
+<TextField onChange={alert('change')} />
+<TextField onBlur={alert('blur')} />
+<TextField onFocus={alert('focus')} />
+~~~
+
+## Example
+
+<!-- STORY -->
+`
+
+export default withDocs(md, () =>
+  <GridLayout>
+    <TextField
+      label='onChange'
+      onChange={action('change')}
+      placeholder='Trigger on change'
+    />
+    <TextField
+      label='onBlur'
+      onBlur={action('blur')}
+      placeholder='Trigger on lose focus'
+    />
+    <TextField
+      label='onFocus'
+      onFocus={action('focus')}
+      placeholder='Trigger on gain focus'
+    />
+  </GridLayout>
+)

--- a/src/TextField/stories/events.jsx
+++ b/src/TextField/stories/events.jsx
@@ -28,19 +28,10 @@ The \`<TextField>\` component accepts multiple events:
 export default withDocs(md, () =>
   <GridLayout>
     <TextField
-      label='onChange'
+      label='Triggers events'
       onChange={action('change')}
-      placeholder='Trigger on change'
-    />
-    <TextField
-      label='onBlur'
       onBlur={action('blur')}
-      placeholder='Trigger on lose focus'
-    />
-    <TextField
-      label='onFocus'
       onFocus={action('focus')}
-      placeholder='Trigger on gain focus'
     />
   </GridLayout>
 )

--- a/src/TextField/stories/index.jsx
+++ b/src/TextField/stories/index.jsx
@@ -3,8 +3,10 @@ import { storiesOf } from '@storybook/react'
 import overview from './overview'
 import states from './states'
 import types from './types'
+import events from './events'
 
 storiesOf('Text Fields', module)
   .add('Overview', overview)
   .add('States', states)
   .add('Types', types)
+  .add('Events', events)


### PR DESCRIPTION
For TC Donations, we use `onBlur` events to do some Google tracking. For example, as a donor progresses through the form, we track a number of events as to which fields they completed, or left blank, etc...

However, we only explicitly passed along `onChange`. I've added `onBlur` and `onFocus` to the `TextField` and `Dropdown` components, plus added specs and demonstrations in the storybook.