### PR TITLE
TC-48 ChipInput tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@theconversation/ui",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theconversation/ui",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "A collection of React components used to build our apps at The Conversation",
   "homepage": "https://github.com/conversation/ui",
   "author": "The Conversation <support@theconversation.com>",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "ui"
   ],
   "main": "dist/index.js",
+  "scripts": {
+    "prepare": "babel --out-dir dist src"
+  },
   "files": [
     "dist"
   ],

--- a/src/ChipInput/ChipInput.jsx
+++ b/src/ChipInput/ChipInput.jsx
@@ -313,6 +313,7 @@ export class ChipInput extends React.Component {
             onFocus={this.handleInputFocus}
             onBlur={this.handleInputBlur}
             inputRef={this.setActualInputRef}
+            id={id}
             value={inputValue}
             placeholder={inputValue.length === 0 && entries.length === 0 ? placeholder : null}
             disabled={disabled}
@@ -327,6 +328,11 @@ export class ChipInput extends React.Component {
 }
 
 ChipInput.propTypes = {
+  /**
+   * Overrides the styles applied to the component.
+   */
+  id: PropTypes.string,
+
   /**
    * Overrides the styles applied to the component.
    */


### PR DESCRIPTION
This PR adds the `id` prop to `propTypes` and applies it to the input.

In addition, it adds a `prepare` section to the npm scripts, to allow for using the component library directly from GitHub without publishing to the registry.