### PR TITLE
[TC-736] Add MenuItem to TCUI, instead of calling @material-ui directly.

### DIFF
--- a/src/MenuItem/MenuItem.jsx
+++ b/src/MenuItem/MenuItem.jsx
@@ -1,0 +1,57 @@
+import MaterialMenuItem from '@material-ui/core/MenuItem'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+/**
+ * The `<MenuItem>` component functionally replaces what would be `option`
+ * elements in a `select` field.
+ #
+ * MenuItems are passed to `Dropdown` components as children.
+ *
+ * ```js
+ * import { Dropdown, MenuItem } from '@theconversation/ui'
+ *
+ * <Dropdown
+ *   label="Country"
+ *   value="AU"
+ * >
+ *   <MenuItem key="1" value="AU">Australia</MenuItem>
+ *   <MenuItem key="2" value="UK">United Kingdom</MenuItem>
+ *   <MenuItem key="3" value="US">United States</MenuItem>
+ * </Dropdown>
+ * ```
+ */
+export const MenuItem = ({ children, ...other }) => (
+  <MaterialMenuItem {...other}>
+    {children}
+  </MaterialMenuItem>
+)
+
+MenuItem.propTypes = {
+  /**
+   * MenuItem contents.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * Overrides the styles applied to the component.
+   */
+  classes: PropTypes.object,
+
+  /**
+   * The component used for the root node. Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.component,
+
+  /**
+   * If `true`, the left and right padding is removed
+   */
+  disableGutters: PropTypes.bool
+}
+
+MenuItem.defaultProps = {
+  disableGutters: false,
+  component: 'li'
+}
+
+export default MenuItem

--- a/src/MenuItem/index.js
+++ b/src/MenuItem/index.js
@@ -1,0 +1,1 @@
+export { default } from './MenuItem'

--- a/src/MenuItem/stories/example.jsx
+++ b/src/MenuItem/stories/example.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { withDocs } from 'storybook-readme'
+
+import { GridLayout } from '../../util'
+import { Dropdown, MenuItem } from '../../index'
+
+const md = `
+# Example
+
+The \`<MenuItem>\` component only is to be used only inside a \`<Dropdown>\`.
+
+Consider it a replacement for an \`<option>\`, and the \`<Dropdown>\`
+is an analogue for a \`<select>\`.
+
+~~~js
+<MenuItem key={} value={}>{text}</MenuItem>
+~~~
+
+## Example
+
+<!-- STORY -->
+`
+
+class ExampleDropdown extends React.Component {
+  state = {
+    value: 'AU'
+  }
+
+  handleChange = event => {
+    this.setState({ value: event.target.value })
+  }
+
+  render () {
+    return (
+      <Dropdown
+        {...this.props}
+        onChange={this.handleChange}
+        value={this.state.value}
+      >
+        <MenuItem key='1' value='AU'>Australia</MenuItem>
+        <MenuItem key='2' value='UK'>United Kingdom</MenuItem>
+        <MenuItem key='3' value='US'>United States</MenuItem>
+      </Dropdown>
+    )
+  }
+}
+
+export default withDocs(md, () =>
+  <GridLayout>
+    <ExampleDropdown
+      onChange={action('change')}
+    />
+  </GridLayout>
+)

--- a/src/MenuItem/stories/index.jsx
+++ b/src/MenuItem/stories/index.jsx
@@ -1,0 +1,8 @@
+import { storiesOf } from '@storybook/react'
+
+import overview from './overview'
+import example from './example'
+
+storiesOf('MenuItems', module)
+  .add('Overview', overview)
+  .add('Example', example)

--- a/src/MenuItem/stories/overview.jsx
+++ b/src/MenuItem/stories/overview.jsx
@@ -1,0 +1,6 @@
+import React from 'react'
+
+import ComponentOverview from '../../ComponentOverview'
+import { MenuItem } from '../MenuItem'
+
+export default () => <ComponentOverview component={MenuItem} />


### PR DESCRIPTION
REFS https://github.com/conversation/tc-donations/pull/702#discussion_r267878803

@tiagoamaro _3 days ago_
I think we should avoid referencing @material-ui as much as possible, since these should be references of @theconversation/ui.

@tiagoamarotiagoamaro _3 days ago_
Also, if the MenuItem MUI delegation does not exist, a new @theconversation/ui should be released with it :)

@markcipollamarkcipolla _3 days ago_ 
Hmmm.... yeah, good point. I'll add it to the TCUI lib.
