### PR TITLE
[TC-703] Update input field UI

### DIFF
--- a/src/form/FormLabel.jsx
+++ b/src/form/FormLabel.jsx
@@ -3,7 +3,8 @@ import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({
   root: {
-    fontSize: theme.typography.pxToRem(14),
+    fontWeight: 'bold',
+    fontSize: theme.typography.pxToRem(12),
     textAlign: 'left'
   }
 })

--- a/src/styles/themes/legacy.js
+++ b/src/styles/themes/legacy.js
@@ -17,7 +17,7 @@ export default memoize(() => createMuiTheme({
     // https://material-ui.com/style/typography/#migration-to-typography-v2
     useNextVariants: true,
 
-    fontFamily: 'Montserrat',
+    fontFamily: 'Noto Sans',
 
     body1: {
       fontSize: '1rem',


### PR DESCRIPTION
## Before:
<img width="236" alt="Screen Shot 2019-03-26 at 11 48 07 am" src="https://user-images.githubusercontent.com/127084/54964021-ec660400-4fbe-11e9-9df7-d41aabe5fb27.png">


## Now: 
<img width="216" alt="Screen Shot 2019-03-26 at 11 47 57 am" src="https://user-images.githubusercontent.com/127084/54963490-19b1b280-4fbd-11e9-81dd-b8830fb62981.png">

This PR sets the default font to Noto Sans for the `legacy` theme, and the label font size/weight is gently changed.