### PR TITLE
Add id, onBlur, and onFocus props to Autocomplete component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add `id`, `onBlur`, and `onFocus` props to `Autocomplete` component
+
 ## 1.15.0 (2019-03-31)
 
 * Upgrade storybook to 5.0.5

--- a/src/Autocomplete/Autocomplete.jsx
+++ b/src/Autocomplete/Autocomplete.jsx
@@ -118,8 +118,11 @@ export const Autocomplete = ({
   error,
   fullWidth,
   helperText,
+  id,
   label,
+  onBlur,
   onChange,
+  onFocus,
   placeholder,
   required,
   suggestions
@@ -139,12 +142,19 @@ export const Autocomplete = ({
     }) => {
       const results = getSuggestions(suggestions, inputValue)
       const isVisible = isOpen && results.length > 0
+      const inputProps = { onBlur, onFocus }
+
+      // Only set the ID property if we are actually overriding it. Otherwise,
+      // let Downshift automatically generate an ID for us.
+      if (id !== undefined) {
+        inputProps.id = id
+      }
 
       return (
         <div className={classes.container}>
           {
             renderInput({
-              InputProps: getInputProps(),
+              InputProps: getInputProps(inputProps),
               disabled,
               error,
               fullWidth,
@@ -192,14 +202,29 @@ Autocomplete.propTypes = {
   helperText: PropTypes.string,
 
   /**
+   * The `id` of the underlying `<input>` element.
+   */
+  id: PropTypes.string,
+
+  /**
    * The text displayed above the dropdown.
    */
   label: PropTypes.string,
 
   /**
+   * The callback function called when the text field loses focus.
+   */
+  onBlur: PropTypes.func,
+
+  /**
    * The callback function called when the dropdown value changes.
    */
   onChange: PropTypes.func,
+
+  /**
+   * The callback function called when the text field gains focus.
+   */
+  onFocus: PropTypes.func,
 
   /**
    * The text displayed inside text field before the user enters a value.

--- a/src/Autocomplete/Autocomplete.test.jsx
+++ b/src/Autocomplete/Autocomplete.test.jsx
@@ -28,6 +28,22 @@ describe('<Autocomplete />', () => {
     })
   })
 
+  describe('with an ID', () => {
+    it('sets the text field ID', () => {
+      const wrapper = mount(
+        <Autocomplete id='foo' />
+      ).find(TextField)
+      expect(wrapper.props().id).toBe('foo')
+    })
+
+    it('sets a default downshift generated ID', () => {
+      const wrapper = mount(
+        <Autocomplete />
+      ).find(TextField)
+      expect(wrapper.props().id).toMatch(/downshift-\d*-input/)
+    })
+  })
+
   describe('with label', () => {
     it('renders a label', () => {
       const wrapper = mount(
@@ -61,6 +77,28 @@ describe('<Autocomplete />', () => {
         wrapper.find('MenuItem').simulate('click')
 
         expect(onChange).toHaveBeenCalledWith({ value: 'AU', label: 'Australia' })
+      })
+    })
+
+    describe('when focussed', () => {
+      it('calls the callback', () => {
+        const onFocus = jest.fn()
+        const wrapper = mount(
+          <Autocomplete onFocus={onFocus} suggestions={suggestions} />
+        )
+        wrapper.find('input').simulate('focus')
+        expect(onFocus).toHaveBeenCalled()
+      })
+    })
+
+    describe('when blurred', () => {
+      it('calls the callback', () => {
+        const onBlur = jest.fn()
+        const wrapper = mount(
+          <Autocomplete onBlur={onBlur} suggestions={suggestions} />
+        )
+        wrapper.find('input').simulate('blur')
+        expect(onBlur).toHaveBeenCalled()
       })
     })
   })

--- a/src/Autocomplete/stories/events.jsx
+++ b/src/Autocomplete/stories/events.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import { withDocs } from 'storybook-readme'
+
+import { GridLayout } from '../../util'
+import { Autocomplete } from '../../index'
+import countries from './countries'
+
+const md = `
+# Events
+
+The \`<Autocomplete>\` component accepts multiple events:
+
+* \`onChange\`: When the field's value changes
+* \`onBlur\`: When the field loses focus
+* \`onFocus\`: When the field gains focus
+
+~~~js
+<Autocomplete onChange={alert('change')} />
+<Autocomplete onBlur={alert('blur')} />
+<Autocomplete onFocus={alert('focus')} />
+~~~
+
+## Example
+
+<!-- STORY -->
+`
+
+export default withDocs(md, () =>
+  <GridLayout>
+    <Autocomplete
+      label='Triggers events'
+      onChange={action('change')}
+      onBlur={action('blur')}
+      onFocus={action('focus')}
+      suggestions={countries}
+    />
+  </GridLayout>
+)

--- a/src/Autocomplete/stories/index.jsx
+++ b/src/Autocomplete/stories/index.jsx
@@ -1,8 +1,10 @@
 import { storiesOf } from '@storybook/react'
 
+import events from './events'
 import overview from './overview'
 import states from './states'
 
 storiesOf('Autocomplete', module)
   .add('Overview', overview)
   .add('States', states)
+  .add('Events', events)


### PR DESCRIPTION
Seems Downshift generates an id (like `downshift-[INTEGER]-input`), and hijacks the events, to make it work the way it wants (to display an autocomplete).

I've explicitly set the id and onBlur so it uses a given prop, or the generated downshift ones.

@nullobject and @tiagoamaro, I'd love your expertise on this.