### PR TITLE
[TC-805] Allow Textfield to pass autoComplete prop

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -63,7 +63,6 @@ export const TextField = ({
   ...other
 }) => {
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined
-
   return (
     <FormControl aria-describedby={helperTextId} disabled={disabled} error={error} fullWidth={fullWidth}>
       {label && (
@@ -84,6 +83,11 @@ export const TextField = ({
 }
 
 TextField.propTypes = {
+  /**
+   * Overrides the styles applied to the component.
+   */
+  autoComplete: PropTypes.string,
+
   /**
    * Overrides the styles applied to the component.
    */
@@ -158,6 +162,7 @@ TextField.propTypes = {
 }
 
 TextField.defaultProps = {
+  autoComplete: 'off',
   disabled: false,
   error: false,
   fullWidth: false,

--- a/src/TextField/TextField.test.jsx
+++ b/src/TextField/TextField.test.jsx
@@ -15,6 +15,15 @@ describe('<TextField />', () => {
     expect(wrapper.props().value).toBe('foo')
   })
 
+  describe('with an autoComplete setting', () => {
+    it('sets the autocomplete attr', () => {
+      const wrapper = shallow(
+        <TextField autoComplete='postal-code' />
+      ).dive().find(InputBase)
+      expect(wrapper.props().autoComplete).toBe('postal-code')
+    })
+  })
+
   describe('when disabled', () => {
     it('disables the form control', () => {
       const wrapper = shallow(


### PR DESCRIPTION
This PR adds the `autoComplete` prop to `TextField`, allowing us to set it both `on` and `off`, but also to more specific browser-helper strings (read more at https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute)

