### PR TITLE
Allow Autocomplete to pass the name prop to the underlying Textfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Allow `Autocomplete` to pass the `name` prop to the underlying `Textfield` component
+
 ## 1.17.0 (2019-04-02)
 
 * Add `id`, `onBlur`, and `onFocus` props to `Autocomplete` component

--- a/src/Autocomplete/Autocomplete.jsx
+++ b/src/Autocomplete/Autocomplete.jsx
@@ -120,6 +120,7 @@ export const Autocomplete = ({
   helperText,
   id,
   label,
+  name,
   onBlur,
   onChange,
   onFocus,
@@ -148,6 +149,12 @@ export const Autocomplete = ({
       // let Downshift automatically generate an ID for us.
       if (id !== undefined) {
         inputProps.id = id
+      }
+
+      // Only set the name property if we are actually overriding it. Otherwise,
+      // don't add a name field.
+      if (name !== undefined) {
+        inputProps.name = name
       }
 
       return (
@@ -210,6 +217,11 @@ Autocomplete.propTypes = {
    * The text displayed above the dropdown.
    */
   label: PropTypes.string,
+
+  /**
+   * The name of the input field
+   */
+  name: PropTypes.string,
 
   /**
    * The callback function called when the text field loses focus.

--- a/src/Autocomplete/Autocomplete.test.jsx
+++ b/src/Autocomplete/Autocomplete.test.jsx
@@ -44,6 +44,22 @@ describe('<Autocomplete />', () => {
     })
   })
 
+  describe('with a name', () => {
+    it('sets the input field name', () => {
+      const wrapper = mount(
+        <Autocomplete name='name' />
+      ).find(TextField)
+      expect(wrapper.props().name).toBe('name')
+    })
+
+    it('does not add a name field', () => {
+      const wrapper = mount(
+        <Autocomplete />
+      ).find(TextField)
+      expect(wrapper.props().name).toBe(undefined)
+    })
+  })
+
   describe('with label', () => {
     it('renders a label', () => {
       const wrapper = mount(


### PR DESCRIPTION
This PR allows the Autocomplete to pass the input field's `name` prop to the underlying TextField.

TC Donations uses the name prop (ala `donation["country"]`) to validate the fields, and send the response to the server. Without it, the `country` attr on the `Subscription` is `nil`.