### PR TITLE
Use MUI `withStyles` instead of `@theconversation/ui/withStyles`

### DIFF
--- a/src/Autocomplete/Autocomplete.jsx
+++ b/src/Autocomplete/Autocomplete.jsx
@@ -4,8 +4,9 @@ import MenuItem from '@material-ui/core/MenuItem'
 import Paper from '@material-ui/core/Paper'
 import PropTypes from 'prop-types'
 import React from 'react'
+import withStyles from '@material-ui/core/styles/withStyles'
 
-import { TextField, withStyles } from '../index'
+import { TextField } from '../index'
 
 function renderInput ({ InputProps, fullWidth, ref, ...other }) {
   const otherProps = { ...other, ...InputProps }


### PR DESCRIPTION
This PR replaces the reference of the `withStyles` high order component (HoC) at the `Automcomplete` component from the `@theconversation/ui` reference to its packaged `@material-ui/core/styles` implementation.

### Description

With a little help of `git-bisect`, I've found that PR's https://github.com/conversation/ui/pull/33 single commit, where the `Autocomplete` component was introduced, was the culprit of making the `make doc` command of being broken. The only difference between how the `Autocomplete` component was written between others was on how Material UI's `withStyles` high order component (HoC) was imported.

### How to fix it?

Other `@theconversation/ui` components import straight from `@material-ui/core/styles`, while the `Autocomplete` was importing it from the own library `index.js`.

This is not a problem on development, but after compressing the JS for its production usage, Storybook seems to mix up the `withStyles` HoC usage, breaking the entire production website (:scream_cat:).