### PR TITLE
[TC-822] Allow specifying the autoComplete prop as a boolean or string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-##1.18.0 (2019-04-02)
+## Unreleased
+
+* Allow specifying the `autoComplete` prop as a boolean or string
+
+## 1.18.0 (2019-04-02)
 
 * Allow `Autocomplete` to pass the `name` prop to the underlying `Textfield` component
 

--- a/src/Autocomplete/Autocomplete.jsx
+++ b/src/Autocomplete/Autocomplete.jsx
@@ -220,7 +220,7 @@ Autocomplete.propTypes = {
   label: PropTypes.string,
 
   /**
-   * The name of the input field
+   * The `name` of the underlying `<input>` element.
    */
   name: PropTypes.string,
 

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -3,6 +3,7 @@ import FormHelperText from '@material-ui/core/FormHelperText'
 import InputBase from '@material-ui/core/InputBase'
 import PropTypes from 'prop-types'
 import React from 'react'
+import isBoolean from 'lodash/isBoolean'
 import withStyles from '@material-ui/core/styles/withStyles'
 
 import FormLabel from '../form/FormLabel'
@@ -53,6 +54,7 @@ const styles = theme => {
  */
 export const TextField = ({
   InputProps,
+  autoComplete,
   disabled,
   error,
   fullWidth,
@@ -64,6 +66,11 @@ export const TextField = ({
 }) => {
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined
 
+  // Sugar for setting autoComplete using a boolean value.
+  if (isBoolean(autoComplete)) {
+    autoComplete = autoComplete ? 'on' : 'off'
+  }
+
   return (
     <FormControl aria-describedby={helperTextId} disabled={disabled} error={error} fullWidth={fullWidth}>
       {label && (
@@ -72,7 +79,7 @@ export const TextField = ({
         </FormLabel>
       )}
 
-      <InputBase {...other} id={id} {...InputProps} />
+      <InputBase {...other} autoComplete={autoComplete} id={id} {...InputProps} />
 
       {helperText && (
         <FormHelperText id={helperTextId}>
@@ -84,6 +91,15 @@ export const TextField = ({
 }
 
 TextField.propTypes = {
+  /**
+   * The `autoComplete` value of the underlying `<input>` element. It can be
+   * specified as either a boolean or string value.
+   */
+  autoComplete: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string
+  ]),
+
   /**
    * Overrides the styles applied to the component.
    */
@@ -158,6 +174,7 @@ TextField.propTypes = {
 }
 
 TextField.defaultProps = {
+  autoComplete: false,
   disabled: false,
   error: false,
   fullWidth: false,

--- a/src/TextField/TextField.test.jsx
+++ b/src/TextField/TextField.test.jsx
@@ -15,6 +15,29 @@ describe('<TextField />', () => {
     expect(wrapper.props().value).toBe('foo')
   })
 
+  describe('with autoComplete', () => {
+    it('converts a true value to "on" for the autoComplete prop', () => {
+      const wrapper = shallow(
+        <TextField autoComplete />
+      ).dive().find(InputBase)
+      expect(wrapper.props().autoComplete).toBe('on')
+    })
+
+    it('converts a false value to "off" for the autoComplete prop', () => {
+      const wrapper = shallow(
+        <TextField autoComplete={false} />
+      ).dive().find(InputBase)
+      expect(wrapper.props().autoComplete).toBe('off')
+    })
+
+    it('passes a string value for the autoComplete prop', () => {
+      const wrapper = shallow(
+        <TextField autoComplete='foo' />
+      ).dive().find(InputBase)
+      expect(wrapper.props().autoComplete).toBe('foo')
+    })
+  })
+
   describe('when disabled', () => {
     it('disables the form control', () => {
       const wrapper = shallow(


### PR DESCRIPTION
You can now specify the `autoComplete` prop as either a boolean or string value for the `TextField` component.

This little bit of sugar should it a touch nicer to use. For example, you don't need to use `autoComplete='on'` to enable autocomplete anymore:

    <TextField autoComplete />

or if you want anything else:

    <TextField autoComplete='email' />