### PR TITLE
[TC-832] Fix TextField overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Set overflow hidden for `TextField` input wrapper
+
 ## 1.18.1 (2019-04-04)
 
 * Allow specifying the `autoComplete` prop as a boolean or string

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -17,6 +17,7 @@ const styles = theme => {
       backgroundColor: theme.palette.common.white,
       border: `1px solid ${borderColor}`,
       borderRadius: 4,
+      overflow: 'hidden',
       transition: theme.transitions.create('border-color', {
         duration: theme.transitions.duration.shorter
       })

--- a/src/TextField/stories/states.jsx
+++ b/src/TextField/stories/states.jsx
@@ -52,5 +52,12 @@ export default withDocs(md, () =>
       onChange={action('change')}
       placeholder='Placeholder text'
     />
+    <TextField
+      inputProps={{ style: { background: 'lightyellow' } }}
+      helperText='Helper text'
+      label='Custom'
+      onChange={action('change')}
+      placeholder='Placeholder text'
+    />
   </GridLayout>
 )


### PR DESCRIPTION
I noticed an issue where a custom background colour for the `<input>` element was being clipped. For example, Safari sets a light yellow background colour if you auto-fill the fields.

Notice how the rounded corners are being clipped:

<img width="541" alt="Screen Shot 2019-04-05 at 11 25 21 am" src="https://user-images.githubusercontent.com/3614/55597883-956ce580-579b-11e9-98a3-b371fa6332ad.png">

To fix this we need to hide overflow on the wrapping container.