### PR TITLE
[TC-842] Rewrite TextField as a class rather than a function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Set overflow hidden for `TextField` input wrapper
+* Rewrite TextField as a class to allow adding refs
 
 ## 1.18.1 (2019-04-04)
 

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -53,42 +53,48 @@ const styles = theme => {
  * />
  * ```
  */
-export const TextField = ({
-  InputProps,
-  autoComplete,
-  disabled,
-  error,
-  fullWidth,
-  helperText,
-  id,
-  label,
-  required,
-  ...other
-}) => {
-  const helperTextId = helperText && id ? `${id}-helper-text` : undefined
+class TextField extends React.Component {
+  render () {
+    const {
+      InputProps,
+      disabled,
+      error,
+      fullWidth,
+      helperText,
+      id,
+      label,
+      required,
+      ...other
+    } = this.props
 
-  // Sugar for setting autoComplete using a boolean value.
-  if (isBoolean(autoComplete)) {
-    autoComplete = autoComplete ? 'on' : 'off'
+    const helperTextId = helperText && id ? `${id}-helper-text` : undefined
+
+    // Sugar for setting autoComplete using a boolean value.
+    let autoComplete = this.props.autoComplete
+    if (isBoolean(autoComplete)) {
+      autoComplete = autoComplete ? 'on' : 'off'
+    }
+
+    return (
+      <FormControl
+        aria-describedby={helperTextId} disabled={disabled} error={error} fullWidth={fullWidth}
+      >
+        {label && (
+          <FormLabel htmlFor={id} required={required}>
+            {label}
+          </FormLabel>
+        )}
+
+        <InputBase {...other} autoComplete={autoComplete} id={id} {...InputProps} />
+
+        {helperText && (
+          <FormHelperText id={helperTextId}>
+            {helperText}
+          </FormHelperText>
+        )}
+      </FormControl>
+    )
   }
-
-  return (
-    <FormControl aria-describedby={helperTextId} disabled={disabled} error={error} fullWidth={fullWidth}>
-      {label && (
-        <FormLabel htmlFor={id} required={required}>
-          {label}
-        </FormLabel>
-      )}
-
-      <InputBase {...other} autoComplete={autoComplete} id={id} {...InputProps} />
-
-      {helperText && (
-        <FormHelperText id={helperTextId}>
-          {helperText}
-        </FormHelperText>
-      )}
-    </FormControl>
-  )
 }
 
 TextField.propTypes = {


### PR DESCRIPTION
I want to, in an outer component on TC Donations, add a ref to a
TextField, but you can't add refs to functions, only classes.

https://reactjs.org/docs/refs-and-the-dom.html#refs-and-function-components