### PR TITLE
Set aria-label on DonationDialog close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Set ARIA label on `DonationDialog` close button
+
 ## 1.19.1 (2019-04-11)
 
 * Include non-JS assets in output directory

--- a/src/dialog/DonationDialog.jsx
+++ b/src/dialog/DonationDialog.jsx
@@ -130,7 +130,8 @@ DonationDialog.propTypes = {
 DonationDialog.defaultProps = {
   open: false,
   href: 'http://example.com',
-  donateText: 'Donate'
+  donateText: 'Donate',
+  closeText: 'Close'
 }
 
 export default withStyles(styles)(DonationDialog)

--- a/src/dialog/DonationDialog.jsx
+++ b/src/dialog/DonationDialog.jsx
@@ -76,8 +76,8 @@ export const DonationDialog = ({ children, open, onVisible, onClose, classes, hr
   return (
     <MaterialDialog {...dialogProps} >
       <MaterialDialogActions className={classes.topActions}>
-        <MaterialIconButton color='inherit' className={classes.close} onClick={onClose}>
-          <CloseIcon>{closeText}</CloseIcon>
+        <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
+          <CloseIcon />
         </MaterialIconButton>
       </MaterialDialogActions>
       {children}

--- a/src/dialog/stories/donationDialog.jsx
+++ b/src/dialog/stories/donationDialog.jsx
@@ -41,7 +41,7 @@ class ExampleDialog extends React.Component {
         <React.Fragment>
           <h2>Example</h2>
           <Button colour='primary' onClick={this.handleOpen}>Open Dialog</Button>
-          <DonationDialog href='https://donate.theconversation.com' open={this.state.open} onClose={this.handleClose} donateText='Donate now' closeText='close'>
+          <DonationDialog href='https://donate.theconversation.com' open={this.state.open} onClose={this.handleClose} donateText='Donate now'>
             <DialogAvatar src={koala} />
             <DialogInlineTitle>Support close combat training for koalas</DialogInlineTitle>
             <DialogContent>


### PR DESCRIPTION
This PR fixes an issue with the ARIA label for the close button on the `DonationDialog` component.