### PR TITLE
[TC-855] Set the DonationDialog actions bottom margin to 32px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Set the `DonationDialog` actions bottom margin to 32px
+
 ## 1.19.2 (2019-04-11)
 
 * Set ARIA label on `DonationDialog` close button

--- a/src/dialog/DonationDialog.jsx
+++ b/src/dialog/DonationDialog.jsx
@@ -22,7 +22,8 @@ const styles = theme => ({
   },
   bottomActions: {
     justifyContent: 'center',
-    marginTop: 0
+    marginTop: 0,
+    marginBottom: theme.spacing.unit * 4
   },
   close: {
     margin: theme.spacing.unit

--- a/src/dialog/DonationDialog.jsx
+++ b/src/dialog/DonationDialog.jsx
@@ -23,7 +23,7 @@ const styles = theme => ({
   bottomActions: {
     justifyContent: 'center',
     marginTop: 0,
-    marginBottom: theme.spacing.unit * 4
+    marginBottom: theme.spacing.unit * 6
   },
   close: {
     margin: theme.spacing.unit


### PR DESCRIPTION
This PR makes an adjustment to the `DonationDialog` actions bottom margin.

By using a 4x multiple of the `theme.spacing.unit` variable (which is 8px by default), we end up with 32px. This means that we can scale this margin with the rest of the spacing, if we change the theme spacing later.

![Screen Shot 2019-04-11 at 4 46 10 pm](https://user-images.githubusercontent.com/3614/55936339-5813c680-5c79-11e9-8204-fcd205e0427e.png)