### PR TITLE
Add article donation banner

### DIFF
--- a/src/Avatar/Avatar.jsx
+++ b/src/Avatar/Avatar.jsx
@@ -37,7 +37,7 @@ Avatar.propTypes = {
   /**
    * The size of the button, limited to select sizes.
    */
-  size: PropTypes.oneOf([DEFAULT_AVATAR_SIZE])
+  size: PropTypes.oneOf([48, DEFAULT_AVATAR_SIZE])
 }
 
 Avatar.defaultProps = {

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -2,13 +2,18 @@ import MaterialButton from '@material-ui/core/Button'
 import PropTypes from 'prop-types'
 import React from 'react'
 import withStyles from '@material-ui/core/styles/withStyles'
+import classNames from 'classnames'
 
 const styles = theme => ({
   root: {
-    boxShadow: "none",
-    "&:active": {
-      boxShadow: "none",
+    boxShadow: 'none',
+    '&:active': {
+      boxShadow: 'none'
     }
+  },
+  prominent: {
+    paddingLeft: '2.5em',
+    paddingRight: '2.5em'
   }
 })
 
@@ -24,11 +29,19 @@ const styles = theme => ({
   * </Button>
   * ```
   */
-const Button = ({ children, colour, ...other }) => (
-  <MaterialButton color={colour} {...other}>
-    {children}
-  </MaterialButton>
-)
+const Button = ({ classes, children, colour, prominent, className, ...other }) => {
+  const muiClasses = {
+    root: classes.root
+  }
+
+  const joinedClassNames = classNames(className, { [classes.prominent]: prominent })
+
+  return (
+    <MaterialButton classes={muiClasses} color={colour} className={joinedClassNames} {...other}>
+      {children}
+    </MaterialButton>
+  )
+}
 
 Button.propTypes = {
   /**
@@ -69,6 +82,12 @@ or a component.
   fullWidth: PropTypes.bool,
 
   /**
+   * If true, the button will have slightly more padding around the text,
+   * making it a little bit larger than usual.
+   */
+  prominent: PropTypes.bool,
+
+  /**
    * The URL to link to when the button is clicked. If defined, an `<a>`
    * element will be used as the root node.
    */
@@ -94,6 +113,7 @@ Button.defaultProps = {
   colour: 'default',
   disabled: false,
   fullWidth: false,
+  prominent: false,
   size: 'medium',
   variant: 'contained'
 }

--- a/src/Button/Button.jsx
+++ b/src/Button/Button.jsx
@@ -1,6 +1,16 @@
 import MaterialButton from '@material-ui/core/Button'
 import PropTypes from 'prop-types'
 import React from 'react'
+import withStyles from '@material-ui/core/styles/withStyles'
+
+const styles = theme => ({
+  root: {
+    boxShadow: "none",
+    "&:active": {
+      boxShadow: "none",
+    }
+  }
+})
 
 /**
   * The `<Button>` component allows users to take actions, by tapping or
@@ -88,4 +98,4 @@ Button.defaultProps = {
   variant: 'contained'
 }
 
-export default Button
+export default withStyles(styles)(Button)

--- a/src/Button/Button.test.jsx
+++ b/src/Button/Button.test.jsx
@@ -8,14 +8,14 @@ describe('<Button />', () => {
   it('maps the colour prop', () => {
     const wrapper = shallow(
       <Button colour='primary'>Click Me!</Button>
-    ).find(MaterialButton)
+    ).dive().find(MaterialButton)
     expect(wrapper.props().color).toBe('primary')
   })
 
   it('passes props to Material UI', () => {
     const wrapper = shallow(
       <Button disabled>Click Me!</Button>
-    ).find(MaterialButton)
+    ).dive().find(MaterialButton)
     expect(wrapper.props().disabled).toBe(true)
   })
 

--- a/src/ComponentOverview.jsx
+++ b/src/ComponentOverview.jsx
@@ -38,13 +38,17 @@ const PropDefinitionsTable = ({ propDefinitions }) => (
  * based on the docgen data.
  */
 const ComponentOverview = ({ component, heading, children }) => (
-  <div className='markdown-body'>
-    <h1>{heading || 'Overview'}</h1>
-    <Marked md={get(component, '__docgenInfo.description', '')} />
+  <React.Fragment>
+    <div className='markdown-body'>
+      <h1>{heading || 'Overview'}</h1>
+      <Marked md={get(component, '__docgenInfo.description', '')} />
+    </div>
     {children}
-    <h2>Props</h2>
-    <PropDefinitionsTable propDefinitions={propDefinitions(component)} />
-  </div>
+    <div className='markdown-body'>
+      <h2>Props</h2>
+      <PropDefinitionsTable propDefinitions={propDefinitions(component)} />
+    </div>
+  </React.Fragment>
 )
 
 export default ComponentOverview

--- a/src/dialog/DonationDialog.jsx
+++ b/src/dialog/DonationDialog.jsx
@@ -1,4 +1,3 @@
-import MaterialButton from '@material-ui/core/Button'
 import MaterialDialog from '@material-ui/core/Dialog'
 import MaterialIconButton from '@material-ui/core/IconButton'
 import MaterialDialogActions from '@material-ui/core/DialogActions'
@@ -7,6 +6,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import withStyles from '@material-ui/core/styles/withStyles'
 import DialogActions from './DialogActions'
+import Button from '../Button'
 
 const styles = theme => ({
   paper: {
@@ -33,7 +33,6 @@ const styles = theme => ({
   button: {
     backgroundColor: '#fff',
     fontWeight: 'bold',
-    padding: '0.5em 3em',
     '&:hover': {
       backgroundColor: '#f1f1f2'
     }
@@ -83,9 +82,9 @@ export const DonationDialog = ({ children, open, onVisible, onClose, classes, hr
       </MaterialDialogActions>
       {children}
       <DialogActions className={classes.bottomActions}>
-        <MaterialButton href={href} className={classes.button}>
+        <Button prominent href={href} className={classes.button}>
           {donateText}
-        </MaterialButton>
+        </Button>
       </DialogActions>
     </MaterialDialog>
   )

--- a/src/dialog/stories/donationDialog.jsx
+++ b/src/dialog/stories/donationDialog.jsx
@@ -39,7 +39,10 @@ class ExampleDialog extends React.Component {
     return (
       <ComponentOverview heading='DonationDialog' component={UnwrappedDonationDialog}>
         <React.Fragment>
-          <h2>Example</h2>
+          <div className='markdown-body'>
+            <h2>Example</h2>
+          </div>
+
           <Button colour='primary' onClick={this.handleOpen}>Open Dialog</Button>
           <DonationDialog href='https://donate.theconversation.com' open={this.state.open} onClose={this.handleClose} donateText='Donate now'>
             <DialogAvatar src={koala} />

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export { default as withTheme } from '@material-ui/core/styles/withTheme'
 // Our API.
 export { ThemeProvider } from './styles'
 export { colours }
+export { default as ArticleDonationBanner } from './promo/ArticleDonationBanner'
 export { default as Autocomplete } from './Autocomplete'
 export { default as Avatar } from './Avatar'
 export { default as Button } from './Button'

--- a/src/promo/ArticleDonationBanner.jsx
+++ b/src/promo/ArticleDonationBanner.jsx
@@ -45,12 +45,9 @@ const styles = theme => ({
 export const ArticleDonationBanner = ({ children, classes, href, donateText }) => {
   const filteredChildren = children.filter(component => component.key !== 'attribution')
   const attribution = children.filter(component => component.key === 'attribution')
-  const paperClasses = {
-    root: classes.root
-  }
 
   return (
-    <Paper elevation={0} classes={paperClasses}>
+    <Paper elevation={0} className={classes.root}>
       {filteredChildren}
       <Typography paragraph>
         <Button prominent className={classes.button} href={href}>{donateText}</Button>

--- a/src/promo/ArticleDonationBanner.jsx
+++ b/src/promo/ArticleDonationBanner.jsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import withStyles from '@material-ui/core/styles/withStyles'
+import Paper from '@material-ui/core/Paper'
+import Typography from '../Typography'
+import { Button } from '../index'
+
+const styles = theme => ({
+  root: {
+    backgroundColor: theme.palette.grey[50],
+    padding: theme.spacing.unit * 3
+  },
+  // TODO: this is temporary while we work out what to do about
+  // themes and palettes properly
+  button: {
+    backgroundColor: theme.palette.core && theme.palette.core.main,
+    color: theme.palette.primary.contrastText,
+    fontWeight: 'bold',
+    '&:hover': {
+      backgroundColor: theme.palette.core && theme.palette.core.main
+    }
+  }
+})
+
+/**
+ * The `<ArticleDonationBanner>` component is a block that can contain text and
+ * attribution, intended for donations campaigns. It has a callback, `onVisible`,
+ * for tracking impressions.
+ *
+ * ~~~js
+ * <ArticleDonationBanner href="http://donate.theconverastion.com" donateText="Donate now">
+ *   <Typography variant="h6" gutterBottom>Some text</Typography>
+ *   <Typography variant="body1" paragraph>
+ *     More text
+ *   </Typography>
+ *   <div key="attribution">
+ *     <Typography gutterBottom>
+ *       <Person name="Full name" caption="A fine caption" />
+ *     </Typography>
+ *     <Avatar size={48} />
+ *   </div>
+ * </ArticleDonationBanner>
+ * ~~~
+ *
+ */
+export const ArticleDonationBanner = ({ children, classes, href, donateText }) => {
+  const filteredChildren = children.filter(component => component.key !== 'attribution')
+  const attribution = children.filter(component => component.key === 'attribution')
+  const paperClasses = {
+    root: classes.root
+  }
+
+  return (
+    <Paper elevation={0} classes={paperClasses}>
+      {filteredChildren}
+      <Typography paragraph>
+        <Button prominent className={classes.button} href={href}>{donateText}</Button>
+      </Typography>
+      {attribution}
+    </Paper>
+  )
+}
+
+ArticleDonationBanner.propTypes = {
+  /**
+   * Any sub-components you want to render. Children with a key of 'attribution'
+   * will be rendered below the donate button.
+   */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * URL that clicking donate button points to
+   */
+  href: PropTypes.string,
+
+  /**
+   * Text that appears in the donate button
+   */
+  donateText: PropTypes.string
+}
+
+ArticleDonationBanner.defaultProps = {
+  href: 'http://example.com',
+  donateText: 'Donate'
+}
+
+export default withStyles(styles)(ArticleDonationBanner)

--- a/src/promo/ArticleDonationBanner.jsx
+++ b/src/promo/ArticleDonationBanner.jsx
@@ -24,11 +24,10 @@ const styles = theme => ({
 
 /**
  * The `<ArticleDonationBanner>` component is a block that can contain text and
- * attribution, intended for donations campaigns. It has a callback, `onVisible`,
- * for tracking impressions.
+ * attribution, intended for donations campaigns.
  *
  * ~~~js
- * <ArticleDonationBanner href="http://donate.theconverastion.com" donateText="Donate now">
+ * <ArticleDonationBanner href="http://donate.theconversation.com" donateText="Donate now">
  *   <Typography variant="h6" gutterBottom>Some text</Typography>
  *   <Typography variant="body1" paragraph>
  *     More text
@@ -63,7 +62,7 @@ export const ArticleDonationBanner = ({ children, classes, href, donateText }) =
 
 ArticleDonationBanner.propTypes = {
   /**
-   * Any sub-components you want to render. Children with a key of 'attribution'
+   * Any sub-components you want to render. Children with a key of `attribution`
    * will be rendered below the donate button.
    */
   children: PropTypes.node.isRequired,

--- a/src/promo/ArticleDonationBanner.test.jsx
+++ b/src/promo/ArticleDonationBanner.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import ArticleDonationBanner from './ArticleDonationBanner'
+
+describe('<ArticleDonationBanner />', () => {
+  describe('child node filtering', () => {
+    it('renders donate button before children with key "attribution"', () => {
+      const wrapper = shallow(
+        <ArticleDonationBanner>
+          <div>foo</div>
+          <div key='attribution'>bar</div>
+        </ArticleDonationBanner>
+      ).dive()
+
+      expect(wrapper.childAt(0).text()).toEqual('foo')
+      expect(wrapper.childAt(1).html()).toContain('Donate')
+      expect(wrapper.childAt(2).text()).toEqual('bar')
+    })
+  })
+})

--- a/src/promo/stories/article_donation_banner.jsx
+++ b/src/promo/stories/article_donation_banner.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import ComponentOverview from '../../ComponentOverview'
+import ArticleDonationBanner, { ArticleDonationBanner as UnwrappedArticleDonationBanner } from '../ArticleDonationBanner'
+import { Avatar, Person, Typography } from '../../index'
+
+export default () => (
+  <ComponentOverview heading='ArticleDonationBanner' component={UnwrappedArticleDonationBanner}>
+    <div className='markdown-body'>
+      <h2>Example</h2>
+    </div>
+
+    <ArticleDonationBanner href='http://donate.theconverastion.com' donateText='Donate now'>
+      <Typography variant='h6' gutterBottom>Before you go...</Typography>
+      <Typography variant='body1' paragraph>
+        The Conversation serves society by making knowledge accessible to everyone, not just a select few. Our only agenda is a better informed public. If you care about what we do please make a donation now and help secure our future.
+      </Typography>
+      <div key='attribution'>
+        <Typography gutterBottom>
+          <Person name='Misha Ketchell' caption='Editor' />
+        </Typography>
+        <Avatar size={48} />
+      </div>
+    </ArticleDonationBanner>
+  </ComponentOverview>
+)

--- a/src/promo/stories/index.js
+++ b/src/promo/stories/index.js
@@ -1,0 +1,6 @@
+import { storiesOf } from '@storybook/react'
+
+import articleDonationBanner from './article_donation_banner'
+
+storiesOf('Promos', module)
+  .add('ArticleDonationBanner', articleDonationBanner)

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -23,12 +23,12 @@ const theme = createMuiTheme({
 
     fontFamily: 'Noto Sans',
 
-    h1: { fontFamily: 'Montserrat' },
-    h2: { fontFamily: 'Montserrat' },
-    h3: { fontFamily: 'Montserrat' },
-    h4: { fontFamily: 'Montserrat' },
-    h5: { fontFamily: 'Montserrat' },
-    h6: { fontFamily: 'Montserrat' },
+    h1: { fontFamily: 'Montserrat', fontWeight: 700 },
+    h2: { fontFamily: 'Montserrat', fontWeight: 700 },
+    h3: { fontFamily: 'Montserrat', fontWeight: 700 },
+    h4: { fontFamily: 'Montserrat', fontWeight: 600 },
+    h5: { fontFamily: 'Montserrat', fontWeight: 600 },
+    h6: { fontFamily: 'Montserrat', fontWeight: 700 },
 
     body1: {
       fontFamily: 'Libre Baskerville',


### PR DESCRIPTION
This adds the article donation banner component. The component itself is really pretty simple, so the value is mostly in the examples. The child node splitting is the only real complicated part, this is mostly due to some unanswered questions to do with our themes and colour palettes that we should revisit.

This is what it looks like:

![Screenshot at 2019-04-11 18-32-43](https://user-images.githubusercontent.com/2295892/55942654-379f3880-5c88-11e9-9963-3e78456249d9.png)

I haven't added the "small layout" detection stuff yet. Mostly so we can get this into TC now. Will start working on that now (for merging in another PR).