### PR TITLE
Allow sharing of class name generator across each ThemeProvider

### DIFF
--- a/src/styles/ThemeProvider.jsx
+++ b/src/styles/ThemeProvider.jsx
@@ -7,8 +7,8 @@ import defaultTheme from './themes/default'
 
 const theme = defaultTheme()
 
-const ThemeProvider = ({ children, sheetsManager, sheetsRegistry, ...other }) => (
-  <JssProvider registry={sheetsRegistry}>
+const ThemeProvider = ({ children, sheetsManager, sheetsRegistry, generateClassName, ...other }) => (
+  <JssProvider registry={sheetsRegistry} generateClassName={generateClassName} >
     <MuiThemeProvider theme={theme} sheetsManager={sheetsManager} {...other} >
       {children}
     </MuiThemeProvider>
@@ -29,7 +29,13 @@ ThemeProvider.propTypes = {
   /**
    * A `sheetsRegistry` is used to keep track of the stylesheet.
    */
-  sheetsRegistry: PropTypes.object
+  sheetsRegistry: PropTypes.object,
+
+  /**
+   * Allows sharing of class name generator so that generated class names
+   * will remain unique even when rendering multiple react trees.
+   */
+  generateClassName: PropTypes.any
 }
 
 export default ThemeProvider


### PR DESCRIPTION
In TC we render multiple react trees, because the React must live alongside legacy code.

This means that in TC we need to be able to share the class name generator across each instance of a ThemeProvider. If the generator is not shared, it's highly likely that the generated classnames will
clash and cause components to have the incorrect styles applied to them.

Adding this prop allows us to share the same instance of name generator and avoid this problem.

ref: https://material-ui.com/customization/css-in-js/#creategenerateclassname-options-class-name-generator

The MUI docs seem to imply that it's the SheetsManager that needs to be shared, but that didn't work. 

I found it was only necessary to share the name generator to get the desired behaviour.

What led me down that path was some documentation for SSR:
https://material-ui.com/guides/server-rendering/#react-class-name-hydration-mismatch

Specifically:
> The class names value relies on the concept of class name generator. The whole page needs to be rendered with a single generator.

So I tried that in TC and it now works as expected. eg

```js
<ThemeProvider generateClassName={getSharedClassNameGenerator()}>
  ...
</ThemeProvider>
```

Can probably make this cleaner with some shared context, but for now I'm going for the lo-fi solution.