### PR TITLE
TC-895 Tweak promo spacing

### DIFF
--- a/src/Person/Person.jsx
+++ b/src/Person/Person.jsx
@@ -6,7 +6,7 @@ const Person = ({ children, name, caption }) => (
   <React.Fragment>
     {children}
     <Typography color='inherit' variant='subtitle1'>{name}</Typography>
-    <Typography color='inherit' variant='caption'>{caption}</Typography>
+    <Typography color='inherit' variant='caption' paragraph>{caption}</Typography>
   </React.Fragment>
 )
 

--- a/src/dialog/DialogContent.jsx
+++ b/src/dialog/DialogContent.jsx
@@ -4,7 +4,7 @@ import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = {
   root: {
-    padding: 24
+    padding: '24px 24px 0'
   }
 }
 


### PR DESCRIPTION
Increased spacing between avatar and person caption
![Screenshot at 2019-04-23 16-49-56](https://user-images.githubusercontent.com/2295892/56560794-c006cd00-65e8-11e9-97d3-e7252f572929.png)

~~Decreased spacing below button to match what's in the design (had to fix some side effects of the avatar change and this was in the area)~~ Removed from PR.
![Screenshot at 2019-04-23 16-54-43](https://user-images.githubusercontent.com/2295892/56561467-8c2ca700-65ea-11e9-8b21-b2355cd939ee.png)

