### PR TITLE
Fix more global CSS colour conflicts

### DIFF
--- a/src/dialog/DonationDialog.jsx
+++ b/src/dialog/DonationDialog.jsx
@@ -31,6 +31,9 @@ const styles = theme => ({
   // Donation button styles are a special case until we decide
   // "inverted" buttons are going to be a more widespread thing
   button: {
+    // We need to mark the colour with `!important` to avoid global hyperlink
+    // styles overriding this value.
+    color: [theme.palette.text.primary, '!important'],
     backgroundColor: '#fff',
     fontWeight: 'bold',
     '&:hover': {

--- a/src/promo/DonationBanner.jsx
+++ b/src/promo/DonationBanner.jsx
@@ -33,6 +33,9 @@ const styles = theme => ({
   // Donation button styles are a special case until we decide
   // "inverted" buttons are going to be a more widespread thing
   button: {
+    // We need to mark the colour with `!important` to avoid global hyperlink
+    // styles overriding this value.
+    color: [theme.palette.text.primary, '!important'],
     backgroundColor: '#fff',
     fontWeight: 'bold',
     '&:hover': {

--- a/src/promo/ThinDonationBanner.jsx
+++ b/src/promo/ThinDonationBanner.jsx
@@ -10,8 +10,10 @@ const styles = theme => ({
     // themes and palettes properly
     backgroundColor: theme.palette.core && theme.palette.core.main,
     padding: '9px 12px', // special case, needs to match padding on existing topbar
-    color: theme.palette.primary.contrastText,
-    fontWeight: 'bold' // TODO: we don't want to be making a habit of this
+    fontWeight: 'bold', // TODO: we don't want to be making a habit of this
+    // We need to mark the colour with `!important` to avoid global hyperlink
+    // styles overriding this value.
+    color: [theme.palette.primary.contrastText, '!important']
   },
   icon: {
     position: 'absolute',


### PR DESCRIPTION
TC has a lot of baggage we can't get rid of just yet. This marks more link text colours as `!important` so that TC's ambitious link styles don't mess with the component library.

See also:
https://github.com/conversation/ui/pull/51

Examples of the problem:
![Screenshot at 2019-04-24 17-12-34](https://user-images.githubusercontent.com/2295892/56639507-315f8200-66b4-11e9-9df2-b2d84eef1061.png)

![Screenshot at 2019-04-24 17-12-43](https://user-images.githubusercontent.com/2295892/56639511-33c1dc00-66b4-11e9-9e45-2789c298149d.png)

