### PR TITLE
[TC-900] Fix overflow when focused on DropDown components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Minor design fix to `Dropdown` to avoid `:focus` overflow of background
+
 ## 2.0.0 (2019-04-29)
 
 * Change the `DonationDialog` `href` prop to an `onClick` callback

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -33,7 +33,7 @@ const styles = theme => {
       borderColor: theme.palette.error.border
     },
     input: {
-      padding: '10px 32px 10px 12px'
+      padding: '10px 20px 10px 12px'
     }
   }
 }


### PR DESCRIPTION
We were seeing a faint background colour to the right of the `Dropdown` when `:focus`; the `padding-right` was a smidge too big.

#### Before:
![Screen Shot 2019-04-29 at 4 40 28 pm](https://user-images.githubusercontent.com/127084/56879768-8da01880-6a9d-11e9-8179-d2752f29f977.png)

### After:
![Screen Shot 2019-04-29 at 4 40 34 pm](https://user-images.githubusercontent.com/127084/56879770-909b0900-6a9d-11e9-93a6-e36878da68b0.png)
