### PR TITLE
[TC-942] Add open prop to the DonationBanner component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Add `open` prop to the `DonationBanner` component
+
 ## 2.0.1 (2019-04-30)
 
 * Minor design fix to `Dropdown` to avoid `:focus` overflow of background

--- a/src/promo/DonationBanner.jsx
+++ b/src/promo/DonationBanner.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
-import PropTypes from 'prop-types'
-import withStyles from '@material-ui/core/styles/withStyles'
-import Paper from '@material-ui/core/Paper'
-import MaterialIconButton from '@material-ui/core/IconButton'
-import CloseIcon from '@material-ui/icons/Close'
 import Button from '../Button'
+import CloseIcon from '@material-ui/icons/Close'
+import MaterialIconButton from '@material-ui/core/IconButton'
+import Paper from '@material-ui/core/Paper'
+import PropTypes from 'prop-types'
+import React from 'react'
 import Typography from '../Typography'
+import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({
   // TODO: this is temporary while we work out what to do about
@@ -60,8 +60,14 @@ export const DonationBanner = ({
   closeText,
   donateText,
   onClick,
-  onClose
+  onClose,
+  open
 }) => {
+  // Don't bother rendering if it's not open.
+  if (!open) {
+    return null
+  }
+
   return (
     <Paper className={classes.paper} elevation={0}>
       <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
@@ -99,10 +105,16 @@ DonationBanner.propTypes = {
   /**
    * The callback called when banner is dismissed.
    */
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
+
+  /**
+   * A boolean value indicating whether the banner is currently displayed.
+   */
+  open: PropTypes.bool
 }
 
 DonationBanner.defaultProps = {
+  open: false,
   donateText: 'Donate now',
   closeText: 'Close'
 }

--- a/src/promo/DonationBanner.test.jsx
+++ b/src/promo/DonationBanner.test.jsx
@@ -1,10 +1,9 @@
 import Button from '../Button'
+import DonationBanner from './DonationBanner'
 import MaterialIconButton from '@material-ui/core/IconButton'
 import Paper from '@material-ui/core/Paper'
 import React from 'react'
 import { shallow } from 'enzyme'
-
-import DonationBanner from './DonationBanner'
 
 describe('<DonationBanner />', () => {
   it('is is visible when the "open" prop is true', () => {

--- a/src/promo/DonationBanner.test.jsx
+++ b/src/promo/DonationBanner.test.jsx
@@ -1,11 +1,19 @@
+import Button from '../Button'
+import MaterialIconButton from '@material-ui/core/IconButton'
+import Paper from '@material-ui/core/Paper'
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import Button from '../Button'
 import DonationBanner from './DonationBanner'
-import MaterialIconButton from '@material-ui/core/IconButton'
 
 describe('<DonationBanner />', () => {
+  it('is is visible when the "open" prop is true', () => {
+    const wrapper = shallow(<DonationBanner open>foo</DonationBanner>)
+    expect(wrapper.dive().find(Paper).length).toBe(1)
+    wrapper.setProps({ open: false })
+    expect(wrapper.dive().find(Paper).length).toBe(0)
+  })
+
   describe('onClick callback', () => {
     it('is called when button is clicked', () => {
       const onClick = jest.fn()

--- a/src/promo/DonationDialog.test.jsx
+++ b/src/promo/DonationDialog.test.jsx
@@ -1,9 +1,8 @@
+import Button from '../Button'
+import DonationDialog from './DonationDialog'
 import MaterialIconButton from '@material-ui/core/IconButton'
 import React from 'react'
 import { shallow, mount } from 'enzyme'
-
-import Button from '../Button'
-import DonationDialog from './DonationDialog'
 
 describe('<DonationDialog />', () => {
   describe('onClick callback', () => {

--- a/src/promo/stories/donationBanner.jsx
+++ b/src/promo/stories/donationBanner.jsx
@@ -11,14 +11,14 @@ function ExampleBanner () {
     action('clicked')(event)
   }
 
-  const handleClose = event => {
-    setOpen(false)
-    action('close')(event)
-  }
-
   const handleOpen = event => {
     setOpen(true)
     action('open')(event)
+  }
+
+  const handleClose = event => {
+    setOpen(false)
+    action('close')(event)
   }
 
   return (

--- a/src/promo/stories/donationBanner.jsx
+++ b/src/promo/stories/donationBanner.jsx
@@ -1,16 +1,41 @@
-import React from 'react'
 import ComponentOverview from '../../ComponentOverview'
 import DonationBanner, { DonationBanner as UnwrappedDonationBanner } from '../DonationBanner'
+import React, { useState } from 'react'
+import { Button } from '../../index'
 import { action } from '@storybook/addon-actions'
 
-export default () => (
-  <ComponentOverview heading='DonationBanner' component={UnwrappedDonationBanner}>
-    <div className='markdown-body'>
-      <h2>Example</h2>
-    </div>
+function ExampleBanner () {
+  const [open, setOpen] = useState(true)
 
-    <DonationBanner onClick={action('clicked')}>
-      The Conversation provides clean information in a world infected with spin. Please donate.
-    </DonationBanner>
-  </ComponentOverview>
+  const handleClick = event => {
+    action('clicked')(event)
+  }
+
+  const handleClose = event => {
+    setOpen(false)
+    action('close')(event)
+  }
+
+  const handleOpen = event => {
+    setOpen(true)
+    action('open')(event)
+  }
+
+  return (
+    <ComponentOverview heading='DonationBanner' component={UnwrappedDonationBanner}>
+      <div className='markdown-body'>
+        <h2>Example</h2>
+      </div>
+
+      {!open && <Button colour='primary' onClick={handleOpen}>Open Banner</Button>}
+
+      <DonationBanner onClick={handleClick} onClose={handleClose} open={open}>
+        The Conversation provides clean information in a world infected with spin. Please donate.
+      </DonationBanner>
+    </ComponentOverview>
+  )
+}
+
+export default () => (
+  <ExampleBanner />
 )

--- a/src/promo/stories/donationDialog.jsx
+++ b/src/promo/stories/donationDialog.jsx
@@ -1,5 +1,5 @@
 import ComponentOverview from '../../ComponentOverview'
-import React from 'react'
+import React, { useState } from 'react'
 import { action } from '@storybook/addon-actions'
 
 import {
@@ -20,43 +20,44 @@ import koala from './koala.png'
 
 const CONTENT = 'Koalas want to eat leaves and sleep all day, they need your help to achieve this ideal lifestyle. By donating $5 today, you can help keep koalas safe from Instagrammers and robot vacuum cleaners.'
 
-class ExampleDialog extends React.Component {
-  state = {
-    open: false
+function ExampleDialog () {
+  const [open, setOpen] = useState(false)
+
+  const handleClick = event => {
+    action('clicked')(event)
   }
 
-  handleOpen = event => {
+  const handleOpen = event => {
     action('open')(event)
-    this.setState({ open: true })
+    setOpen(true)
   }
 
-  handleClose = event => {
+  const handleClose = event => {
     action('close')(event)
-    this.setState({ open: false })
+    setOpen(false)
   }
 
-  render () {
-    return (
-      <ComponentOverview heading='DonationDialog' component={UnwrappedDonationDialog}>
-        <React.Fragment>
-          <div className='markdown-body'>
-            <h2>Example</h2>
-          </div>
+  return (
+    <ComponentOverview heading='DonationDialog' component={UnwrappedDonationDialog}>
+      <React.Fragment>
+        <div className='markdown-body'>
+          <h2>Example</h2>
+        </div>
 
-          <Button colour='primary' onClick={this.handleOpen}>Open Dialog</Button>
-          <DonationDialog onClick={action('clicked')} open={this.state.open} onClose={this.handleClose} donateText='Donate now'>
-            <DialogAvatar src={koala} />
-            <DialogInlineTitle>Support close combat training for koalas</DialogInlineTitle>
-            <DialogContent>
-              <Typography variant='body2'>{CONTENT}</Typography>
-              <MiniDivider />
-              <Person name='Colonel Koala' caption='Leader of the Koala Freedom Collective' />
-            </DialogContent>
-          </DonationDialog>
-        </React.Fragment>
-      </ComponentOverview>
-    )
-  }
+        <Button colour='primary' onClick={handleOpen}>Open Dialog</Button>
+
+        <DonationDialog onClick={handleClick} open={open} onClose={handleClose} donateText='Donate now'>
+          <DialogAvatar src={koala} />
+          <DialogInlineTitle>Support close combat training for koalas</DialogInlineTitle>
+          <DialogContent>
+            <Typography variant='body2'>{CONTENT}</Typography>
+            <MiniDivider />
+            <Person name='Colonel Koala' caption='Leader of the Koala Freedom Collective' />
+          </DialogContent>
+        </DonationDialog>
+      </React.Fragment>
+    </ComponentOverview>
+  )
 }
 
 export default () => (


### PR DESCRIPTION
This PR adds an `open` prop to the `DonationBanner` component. This allows it to behave in much the same way as the `DonationDialog` component, where it is not visible when `open` is set to `false`.

I also refactored the `DonationDialog` story to use the react hooks API.

## How to Test

- Fire up storybook: `make storybook`
- Check that you can close the donation banner