### PR TITLE
[TC-947] Tweak the ArticleDonationBanner background colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Set the `ArticleDonationBanner` background colour to `#f8f8f8`
+
 ## 2.1.0 (2019-04-30)
 
 * Add `open` prop to the `DonationBanner` component

--- a/src/promo/ArticleDonationBanner.jsx
+++ b/src/promo/ArticleDonationBanner.jsx
@@ -7,7 +7,7 @@ import { Button } from '../index'
 
 const styles = theme => ({
   root: {
-    backgroundColor: theme.palette.grey[50],
+    backgroundColor: '#f8f8f8',
     padding: theme.spacing.unit * 3
   },
   // TODO: this is temporary while we work out what to do about


### PR DESCRIPTION
@ZoeJazz noticed that the background colour for the `ArticleDonationBanner` should be `#f8f8f8`.

I hard-coded this value, but perhaps we should look at adding it to our gray palette?