### PR TITLE
Allow text field type 'email'

### DIFF
--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -166,7 +166,7 @@ TextField.propTypes = {
   /**
    * The type of the text field.
    */
-  type: PropTypes.oneOf(['text', 'password', 'number']),
+  type: PropTypes.oneOf(['email', 'text', 'password', 'number']),
 
   /**
    * The value of the text field.

--- a/src/TextField/stories/types.jsx
+++ b/src/TextField/stories/types.jsx
@@ -18,6 +18,7 @@ You can set the type of a text field using the \`type\` prop:
 ~~~js
 <TextField type='text' />
 <TextField type='password' />
+<TextField type='email' />
 ~~~
 
 ## Example
@@ -39,6 +40,12 @@ export default withDocs(md, () =>
       label='Password'
       onChange={action('change')}
       type='password'
+    />
+    <TextField
+      helperText='Enter your email'
+      label='Email'
+      onChange={action('change')}
+      type='email'
     />
   </GridLayout>
 )


### PR DESCRIPTION
If the field isn't email you don't get the nice keyboard behaviour on mobile devices (automatic lowercase, and shortcut to @ symbol).

Needed for donations app.