### PR TITLE
[WIP] Update DonationDialog breakpoints

### DIFF
--- a/src/promo/DonationDialog.jsx
+++ b/src/promo/DonationDialog.jsx
@@ -9,13 +9,40 @@ import DialogActions from '../dialog/DialogActions'
 import Button from '../Button'
 
 const styles = theme => ({
+  container: {
+    // For small-medium devices, render the dialog container normally.
+    [theme.breakpoints.down('md')]: {
+      display: 'block',
+      overflowY: 'auto',
+      overflowX: 'hidden'
+    },
+
+    // For medium-large devices, render the dialog container in the centre.
+    [theme.breakpoints.up('md')]: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center'
+    }
+  },
   paper: {
     // TODO: revisit palette colours with what we learned building
     // this component.
     backgroundColor: theme.palette.core && theme.palette.core.main,
     overflow: 'visible', // So we can have the avatar poking out the top
     color: theme.palette.primary.contrastText,
-    textAlign: 'center'
+    textAlign: 'center',
+
+    // For small-medium devices, allow the dialog paper to be full width/height.
+    [theme.breakpoints.down('md')]: {
+      margin: '48px auto',
+      maxHeight: 'none'
+    },
+
+    // For medium-large devices, allow the dialog paper to be centred.
+    [theme.breakpoints.up('md')]: {
+      flex: '0 1 auto',
+      maxHeight: 'calc(100% - 96px)'
+    }
   },
   topActions: {
     margin: 0
@@ -79,14 +106,14 @@ export const DonationDialog = ({
     open,
     onClose,
     onEnter: onVisible,
-    scroll: 'body',
     classes: {
+      container: classes.container,
       paper: classes.paper
     }
   }
 
   return (
-    <MaterialDialog {...dialogProps} >
+    <MaterialDialog {...dialogProps}>
       <MaterialDialogActions className={classes.topActions}>
         <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
           <CloseIcon />


### PR DESCRIPTION
This PR changes the rendering bahaviour of the `DonationDialog` component.

![May-02-2019 10-56-27](https://user-images.githubusercontent.com/3614/57052182-1222af00-6cc9-11e9-9bbb-5d2d32188552.gif)

On small devices, we want to pin the dialog to the top (rather than vertically centre it) and remove the horizontal margins.