### PR TITLE
Amend pop up margin on mobile to match original design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Update donation dialog breakpoints
+
 ## 2.2.2 (2019-05-09)
 
 * Add MUI Radio components from Material UI to list of exported MUI components

--- a/src/promo/DonationDialog.jsx
+++ b/src/promo/DonationDialog.jsx
@@ -9,13 +9,40 @@ import DialogActions from '../dialog/DialogActions'
 import Button from '../Button'
 
 const styles = theme => ({
+  container: {
+    // For small-medium devices, render the dialog container normally.
+    [theme.breakpoints.down('sm')]: {
+      display: 'block',
+      overflowY: 'auto',
+      overflowX: 'hidden'
+    },
+
+    // For medium-large devices, render the dialog container in the centre.
+    [theme.breakpoints.up('sm')]: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center'
+    }
+  },
   paper: {
     // TODO: revisit palette colours with what we learned building
     // this component.
     backgroundColor: theme.palette.core && theme.palette.core.main,
     overflow: 'visible', // So we can have the avatar poking out the top
     color: theme.palette.primary.contrastText,
-    textAlign: 'center'
+    margin: `48px ${theme.spacing.unit * 3}px`,
+    textAlign: 'center',
+
+    // For small devices, allow the dialog paper to be full width/height.
+    [theme.breakpoints.down('sm')]: {
+      maxHeight: 'none'
+    },
+
+    // For medium-large devices, allow the dialog paper to be centred.
+    [theme.breakpoints.up('sm')]: {
+      flex: '0 1 auto',
+      maxHeight: 'calc(100% - 96px)'
+    }
   },
   topActions: {
     margin: 0
@@ -79,14 +106,14 @@ export const DonationDialog = ({
     open,
     onClose,
     onEnter: onVisible,
-    scroll: 'body',
     classes: {
+      container: classes.container,
       paper: classes.paper
     }
   }
 
   return (
-    <MaterialDialog {...dialogProps} >
+    <MaterialDialog {...dialogProps}>
       <MaterialDialogActions className={classes.topActions}>
         <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
           <CloseIcon />


### PR DESCRIPTION
This PR updates the breakpoints for the `DonationDialog` component.

With these new breakpoints, we have:

- For small devices, a 24px horizontal margin around the dialog. It is anchored to the top of the screen and will grow vertically to fit the the dialog content.
- For medium-large devices, the dialog is vertically and horizontally centred on the page.

If anyone knows an easier way to do this, I am all ears 👂

## How to Test

- Fire up storybook and check out the `DonationDialog` at various sizes.

## Screenshots

### Before

Small:

![IMG_3813](https://user-images.githubusercontent.com/3614/57673359-fae7a800-765e-11e9-9453-5b348108be9d.png)

Large:

![localhost_9001_iframe html_id=promos--donationdialog(iPad) (3)](https://user-images.githubusercontent.com/3614/57673567-d0e2b580-765f-11e9-81df-534b6e264042.png)

### After

Small:

![IMG_3812](https://user-images.githubusercontent.com/3614/57673360-fb803e80-765e-11e9-85d3-46511c2a3a82.png)

Large:

![localhost_9001_iframe html_id=promos--donationdialog(iPad) (2)](https://user-images.githubusercontent.com/3614/57673576-d8a25a00-765f-11e9-96a0-2e3ac31f3cf1.png)

