### PR TITLE
Fix placement issues with DonationDialog component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
+* Fix placement issues with `DonationDialog` component
+
 ## 2.2.3 (2019-05-14)
 
-* Update donation dialog breakpoints
+* Update `DonationDialog` breakpoints
 
 ## 2.2.2 (2019-05-09)
 

--- a/src/promo/DonationDialog.jsx
+++ b/src/promo/DonationDialog.jsx
@@ -1,28 +1,22 @@
-import MaterialDialog from '@material-ui/core/Dialog'
-import MaterialIconButton from '@material-ui/core/IconButton'
-import MaterialDialogActions from '@material-ui/core/DialogActions'
 import CloseIcon from '@material-ui/icons/Close'
+import MaterialIconButton from '@material-ui/core/IconButton'
 import PropTypes from 'prop-types'
 import React from 'react'
 import withStyles from '@material-ui/core/styles/withStyles'
+
+import Dialog from '../dialog/Dialog'
 import DialogActions from '../dialog/DialogActions'
 import Button from '../Button'
 
 const styles = theme => ({
+  root: {
+    display: 'flex',
+    overflowY: 'auto'
+  },
   container: {
-    // For small-medium devices, render the dialog container normally.
-    [theme.breakpoints.down('sm')]: {
-      display: 'block',
-      overflowY: 'auto',
-      overflowX: 'hidden'
-    },
-
-    // For medium-large devices, render the dialog container in the centre.
-    [theme.breakpoints.up('sm')]: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center'
-    }
+    height: 'auto', // Override height
+    margin: 'auto', // Horizontally/vertically centre dialog
+    padding: `48px ${theme.spacing.unit * 3}px`
   },
   paper: {
     // TODO: revisit palette colours with what we learned building
@@ -30,19 +24,9 @@ const styles = theme => ({
     backgroundColor: theme.palette.core && theme.palette.core.main,
     overflow: 'visible', // So we can have the avatar poking out the top
     color: theme.palette.primary.contrastText,
-    margin: `48px ${theme.spacing.unit * 3}px`,
-    textAlign: 'center',
-
-    // For small devices, allow the dialog paper to be full width/height.
-    [theme.breakpoints.down('sm')]: {
-      maxHeight: 'none'
-    },
-
-    // For medium-large devices, allow the dialog paper to be centred.
-    [theme.breakpoints.up('sm')]: {
-      flex: '0 1 auto',
-      maxHeight: 'calc(100% - 96px)'
-    }
+    margin: 0,
+    maxHeight: 'none', // Allow dialog height to expand
+    textAlign: 'center'
   },
   topActions: {
     margin: 0
@@ -107,25 +91,26 @@ export const DonationDialog = ({
     onClose,
     onEnter: onVisible,
     classes: {
+      root: classes.root,
       container: classes.container,
       paper: classes.paper
     }
   }
 
   return (
-    <MaterialDialog {...dialogProps}>
-      <MaterialDialogActions className={classes.topActions}>
+    <Dialog {...dialogProps}>
+      <DialogActions className={classes.topActions}>
         <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
           <CloseIcon />
         </MaterialIconButton>
-      </MaterialDialogActions>
+      </DialogActions>
       {children}
       <DialogActions className={classes.bottomActions}>
         <Button prominent className={classes.button} onClick={onClick}>
           {donateText}
         </Button>
       </DialogActions>
-    </MaterialDialog>
+    </Dialog>
   )
 }
 


### PR DESCRIPTION
The modal is now horizontally & vertically centred on all screen sizes.

It will also grow vertically to fit the content, which means the user must scroll the page to see the dialog. This is better than the default Material UI behaviour, which sets a max height on the modal and creates little scroll bars inside it.

It would be good to make this the default behaviour for all of our dialogs in UI (@ZoeJazz and I were chatting about this yesterday), but let's get the behaviour right for the `DonationDialog` and then we can pull it up into our own `Dialog` component later.

## How to Test

- Check the `DonationDialog` at a variety of screen sizes and confirm the scrolling behaviour.

![localhost_9001_iframe html_id=promos--donationdialog(iPhone 6_7_8)](https://user-images.githubusercontent.com/3614/57819488-f8569100-77cb-11e9-9e6b-f4d155c247d4.png)
![localhost_9001_iframe html_id=promos--donationdialog](https://user-images.githubusercontent.com/3614/57819491-fab8eb00-77cb-11e9-99de-5b883a8c6ad4.png)