### PR TITLE
[506] Add storybook examples of Buttons wrapped in each colour theme

### DIFF
--- a/src/Button/stories/colours.jsx
+++ b/src/Button/stories/colours.jsx
@@ -4,6 +4,10 @@ import { withDocs } from 'storybook-readme'
 
 import { Button } from '../../index'
 import { GridLayout } from '../../util'
+import { ThemeProvider } from '../../styles'
+import accentTheme from '../../styles/themes/accent'
+import coreTheme from '../../styles/themes/core'
+import defaultTheme from '../../styles/themes/default'
 
 const COLOURS = ['default', 'primary', 'secondary']
 
@@ -33,11 +37,35 @@ You can set the colour of a button using the \`colour\` prop:
 `
 
 export default withDocs(md, () =>
-  <GridLayout>
-    {COLOURS.map(colour =>
-      <Button key={colour} colour={colour} onClick={action(colour)}>
-        {colour}
-      </Button>
-    )}
-  </GridLayout>
+  <React.Fragment>
+    <ThemeProvider theme={defaultTheme()}>
+      <GridLayout>
+        {COLOURS.map((colour) =>
+          <Button key={colour} colour={colour} onClick={action(colour)}>
+            {colour}
+          </Button>
+        )}
+      </GridLayout>
+    </ThemeProvider>
+
+    <ThemeProvider theme={coreTheme()}>
+      <GridLayout>
+        {COLOURS.map((colour) =>
+          <Button key={colour} colour={colour} onClick={action(colour)}>
+            {colour}
+          </Button>
+        )}
+      </GridLayout>
+    </ThemeProvider>
+
+    <ThemeProvider theme={accentTheme()}>
+      <GridLayout>
+        {COLOURS.map((colour) =>
+          <Button key={colour} colour={colour} onClick={action(colour)}>
+            {colour}
+          </Button>
+        )}
+      </GridLayout>
+    </ThemeProvider>
+  </React.Fragment>
 )

--- a/src/Button/stories/variants.jsx
+++ b/src/Button/stories/variants.jsx
@@ -4,8 +4,13 @@ import { withDocs } from 'storybook-readme'
 
 import { Button } from '../../index'
 import { GridLayout } from '../../util'
+import { ThemeProvider } from '../../styles'
+import accentTheme from '../../styles/themes/accent'
+import coreTheme from '../../styles/themes/core'
+import defaultTheme from '../../styles/themes/default'
 
 const VARIANTS = ['text', 'outlined', 'contained']
+const COLOURS = ['primary', 'secondary']
 
 const md = `
 # Variants
@@ -27,11 +32,51 @@ You can set the variant of a button using the \`variant\` prop:
 `
 
 export default withDocs(md, () =>
-  <GridLayout>
+  <React.Fragment>
     {VARIANTS.map(variant =>
-      <Button key={variant} variant={variant} onClick={action(variant)}>
-        {variant}
-      </Button>
+      <GridLayout>
+        {COLOURS.map(colour =>
+          <Button key={variant + colour} color={colour} variant={variant} onClick={action(variant)}>
+            {variant}
+          </Button>
+        )}
+      </GridLayout>
     )}
-  </GridLayout>
+
+    <ThemeProvider theme={defaultTheme()}>
+      {VARIANTS.map(variant =>
+        <GridLayout>
+          {COLOURS.map(colour =>
+            <Button key={variant + colour} color={colour} variant={variant} onClick={action(variant)}>
+              {variant}
+            </Button>
+          )}
+        </GridLayout>
+      )}
+    </ThemeProvider>
+
+    <ThemeProvider theme={coreTheme()}>
+      {VARIANTS.map(variant =>
+        <GridLayout>
+          {COLOURS.map(colour =>
+            <Button key={variant + colour} color={colour} variant={variant} onClick={action(variant)}>
+              {variant}
+            </Button>
+          )}
+        </GridLayout>
+      )}
+    </ThemeProvider>
+
+    <ThemeProvider theme={accentTheme()}>
+      {VARIANTS.map(variant =>
+        <GridLayout>
+          {COLOURS.map(colour =>
+            <Button key={variant + colour} color={colour} variant={variant} onClick={action(variant)}>
+              {variant}
+            </Button>
+          )}
+        </GridLayout>
+      )}
+    </ThemeProvider>
+  </React.Fragment>
 )


### PR DESCRIPTION
REFS https://trello.com/c/qi1Gl3ai/506-tcui-show-buttons-with-theme-colours

Since https://github.com/conversation/ui/pull/75 merged, we now have access to themes! I thought a good candidate for showing off the theme options is to show the `Button` component in each theme.

![Screen Shot 2019-07-04 at 3 49 09 pm](https://user-images.githubusercontent.com/127084/60643131-80285580-9e75-11e9-8948-6e5ac2c7be02.png)

And the variants:

![Screen Shot 2019-07-04 at 4 10 43 pm](https://user-images.githubusercontent.com/127084/60643407-4e63be80-9e76-11e9-843d-11b5818f8695.png)

