### PR TITLE
[517] Fix existing TCUI donation related banners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Update donation components to use themes
+
 ## 2.6.0 (2019-07-09)
 
 * Update Material UI to 4.2.0 (https://github.com/conversation/ui/pull/81)

--- a/src/dialog/DialogInlineTitle.jsx
+++ b/src/dialog/DialogInlineTitle.jsx
@@ -6,7 +6,6 @@ import Typography from '../Typography'
 
 const styles = theme => ({
   root: {
-    color: theme.palette.primary.contrastText,
     paddingTop: 0,
     paddingBottom: 0
   }

--- a/src/promo/ArticleDonationBanner.jsx
+++ b/src/promo/ArticleDonationBanner.jsx
@@ -4,6 +4,8 @@ import withStyles from '@material-ui/core/styles/withStyles'
 import Paper from '@material-ui/core/Paper'
 import Typography from '../Typography'
 import Button from '../Button'
+import { ThemeProvider } from '../styles'
+import coreTheme from '../styles/themes/core'
 
 const styles = theme => ({
   root: {
@@ -13,16 +15,7 @@ const styles = theme => ({
   // TODO: this is temporary while we work out what to do about
   // themes and palettes properly
   button: {
-    backgroundColor: theme.palette.core && theme.palette.core.main,
-
-    // We need to mark the colour with `!important` to avoid global hyperlink
-    // styles overriding this value.
-    color: [theme.palette.primary.contrastText, '!important'],
-
-    fontWeight: 'bold',
-    '&:hover': {
-      backgroundColor: theme.palette.core && theme.palette.core.main
-    }
+    fontWeight: 'bold'
   }
 })
 
@@ -54,7 +47,9 @@ export const ArticleDonationBanner = ({ children, classes, donateText, onClick }
     <Paper elevation={0} className={classes.root}>
       {filteredChildren}
       <Typography paragraph>
-        <Button prominent className={classes.button} onClick={onClick}>{donateText}</Button>
+        <ThemeProvider theme={coreTheme()}>
+          <Button prominent color='primary' className={classes.button} onClick={onClick}>{donateText}</Button>
+        </ThemeProvider>
       </Typography>
       {attribution}
     </Paper>

--- a/src/promo/DonationBanner.jsx
+++ b/src/promo/DonationBanner.jsx
@@ -1,7 +1,7 @@
 import Button from '../Button'
 import CloseIcon from '@material-ui/icons/Close'
 import MaterialIconButton from '@material-ui/core/IconButton'
-import Paper from '@material-ui/core/Paper'
+import Box from '@material-ui/core/Box'
 import PropTypes from 'prop-types'
 import React from 'react'
 import Typography from '../Typography'
@@ -10,9 +10,7 @@ import neutralPalette from '../styles/palettes/neutral'
 import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({
-  // TODO: this is temporary while we work out what to do about
-  // themes and palettes properly
-  paper: {
+  box: {
     position: 'relative',
     backgroundColor: corePalette[600],
     color: neutralPalette[0],
@@ -35,9 +33,6 @@ const styles = theme => ({
   // Donation button styles are a special case until we decide
   // "inverted" buttons are going to be a more widespread thing
   button: {
-    // We need to mark the colour with `!important` to avoid global hyperlink
-    // styles overriding this value.
-    color: [theme.palette.text.primary, '!important'],
     backgroundColor: neutralPalette[0],
     fontWeight: 'bold',
     '&:hover': {
@@ -71,7 +66,7 @@ export const DonationBanner = ({
   }
 
   return (
-    <Paper className={classes.paper} elevation={0}>
+    <Box bgcolor={corePalette[600]} color={neutralPalette[0]} className={classes.box}>
       <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
         <CloseIcon />
       </MaterialIconButton>
@@ -79,7 +74,7 @@ export const DonationBanner = ({
       <Button prominent className={classes.button} onClick={onClick}>
         {donateText}
       </Button>
-    </Paper>
+    </Box>
   )
 }
 

--- a/src/promo/DonationBanner.jsx
+++ b/src/promo/DonationBanner.jsx
@@ -5,6 +5,7 @@ import Paper from '@material-ui/core/Paper'
 import PropTypes from 'prop-types'
 import React from 'react'
 import Typography from '../Typography'
+import corePalette from '../styles/palettes/core'
 import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({
@@ -12,8 +13,8 @@ const styles = theme => ({
   // themes and palettes properly
   paper: {
     position: 'relative',
-    backgroundColor: theme.palette.core && theme.palette.core.main,
-    color: theme.palette.primary.contrastText,
+    backgroundColor: corePalette[600],
+    color: '#fff',
     borderRadius: 0,
     padding: theme.spacing(4),
     textAlign: 'center'

--- a/src/promo/DonationBanner.jsx
+++ b/src/promo/DonationBanner.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import Typography from '../Typography'
 import corePalette from '../styles/palettes/core'
+import neutralPalette from '../styles/palettes/neutral'
 import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({
@@ -14,7 +15,7 @@ const styles = theme => ({
   paper: {
     position: 'relative',
     backgroundColor: corePalette[600],
-    color: '#fff',
+    color: neutralPalette[0],
     borderRadius: 0,
     padding: theme.spacing(4),
     textAlign: 'center'
@@ -37,7 +38,7 @@ const styles = theme => ({
     // We need to mark the colour with `!important` to avoid global hyperlink
     // styles overriding this value.
     color: [theme.palette.text.primary, '!important'],
-    backgroundColor: '#fff',
+    backgroundColor: neutralPalette[0],
     fontWeight: 'bold',
     '&:hover': {
       backgroundColor: '#f1f1f2'

--- a/src/promo/DonationBanner.test.jsx
+++ b/src/promo/DonationBanner.test.jsx
@@ -1,16 +1,16 @@
 import Button from '../Button'
 import DonationBanner from './DonationBanner'
 import MaterialIconButton from '@material-ui/core/IconButton'
-import Paper from '@material-ui/core/Paper'
+import Box from '@material-ui/core/Box'
 import React from 'react'
 import { shallow } from 'enzyme'
 
 describe('<DonationBanner />', () => {
   it('is is visible when the "open" prop is true', () => {
     const wrapper = shallow(<DonationBanner open>foo</DonationBanner>)
-    expect(wrapper.dive().find(Paper).length).toBe(1)
+    expect(wrapper.dive().find(Box).length).toBe(1)
     wrapper.setProps({ open: false })
-    expect(wrapper.dive().find(Paper).length).toBe(0)
+    expect(wrapper.dive().find(Box).length).toBe(0)
   })
 
   describe('onClick callback', () => {

--- a/src/promo/DonationDialog.jsx
+++ b/src/promo/DonationDialog.jsx
@@ -7,6 +7,7 @@ import React from 'react'
 import withStyles from '@material-ui/core/styles/withStyles'
 import DialogActions from '../dialog/DialogActions'
 import Button from '../Button'
+import corePalette from '../styles/palettes/core'
 
 const styles = theme => ({
   container: {
@@ -27,9 +28,9 @@ const styles = theme => ({
   paper: {
     // TODO: revisit palette colours with what we learned building
     // this component.
-    backgroundColor: theme.palette.core && theme.palette.core.main,
+    backgroundColor: corePalette[600],
     overflow: 'visible', // So we can have the avatar poking out the top
-    color: theme.palette.primary.contrastText,
+    color: '#fff',
     margin: `48px ${theme.spacing(3)}px`,
     textAlign: 'center',
 

--- a/src/promo/DonationDialog.jsx
+++ b/src/promo/DonationDialog.jsx
@@ -8,6 +8,7 @@ import withStyles from '@material-ui/core/styles/withStyles'
 import DialogActions from '../dialog/DialogActions'
 import Button from '../Button'
 import corePalette from '../styles/palettes/core'
+import neutralPalette from '../styles/palettes/neutral'
 
 const styles = theme => ({
   container: {
@@ -30,7 +31,7 @@ const styles = theme => ({
     // this component.
     backgroundColor: corePalette[600],
     overflow: 'visible', // So we can have the avatar poking out the top
-    color: '#fff',
+    color: neutralPalette[0],
     margin: `48px ${theme.spacing(3)}px`,
     textAlign: 'center',
 
@@ -62,7 +63,7 @@ const styles = theme => ({
     // We need to mark the colour with `!important` to avoid global hyperlink
     // styles overriding this value.
     color: [theme.palette.text.primary, '!important'],
-    backgroundColor: '#fff',
+    backgroundColor: neutralPalette[0],
     fontWeight: 'bold',
     '&:hover': {
       backgroundColor: '#f1f1f2'

--- a/src/promo/ThinDonationBanner.jsx
+++ b/src/promo/ThinDonationBanner.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import withStyles from '@material-ui/core/styles/withStyles'
 import corePalette from '../styles/palettes/core'
+import neutralPalette from '../styles/palettes/neutral'
 
 const styles = theme => ({
   button: {
@@ -13,7 +14,7 @@ const styles = theme => ({
 
     // We need to mark the colour with `!important` to avoid global hyperlink
     // styles overriding this value.
-    color: ['#fff', '!important'],
+    color: [neutralPalette[0], '!important'],
 
     fontWeight: 'bold',
     '&:hover': {

--- a/src/promo/ThinDonationBanner.jsx
+++ b/src/promo/ThinDonationBanner.jsx
@@ -3,20 +3,21 @@ import ArrowRightIcon from '@material-ui/icons/KeyboardArrowRight'
 import PropTypes from 'prop-types'
 import React from 'react'
 import withStyles from '@material-ui/core/styles/withStyles'
+import corePalette from '../styles/palettes/core'
 
 const styles = theme => ({
   button: {
     borderRadius: 0,
     justifyContent: 'left',
-    backgroundColor: theme.palette.core && theme.palette.core.main,
+    backgroundColor: corePalette[600],
 
     // We need to mark the colour with `!important` to avoid global hyperlink
     // styles overriding this value.
-    color: [theme.palette.primary.contrastText, '!important'],
+    color: ['#fff', '!important'],
 
     fontWeight: 'bold',
     '&:hover': {
-      backgroundColor: theme.palette.core && theme.palette.core.main
+      backgroundColor: corePalette[600]
     },
     padding: '9px 12px' // special case, needs to match padding on existing topbar
   },


### PR DESCRIPTION
### Relies on https://github.com/conversation/ui/pull/81 being merged first

When we added the new themes, we naffed the donation-related banners' styling a smidge. This was because we changed the default colours and how we structured the themes.

I've made them look as expected again. Most of these are pulling in the `core` palette, and specifying the colour manually. The ones where we were setting backgrorund colours required this method.

One I could get away with using a `ThemeProvider` was in the below-article banner, as only the button needed colouring.

I think this is okay for now; we built those components pre-themes, so keeping them the same for now while we can generalise them for future use (like in the case of making the `ThinBanner`, which was a generalisation of the `ThinDonationBanner`).


# Left is this PR, right is current master

![Screen Shot 2019-07-05 at 3 11 52 pm (2)](https://user-images.githubusercontent.com/127084/60699466-58012b00-9f37-11e9-9f80-12a386c73cf7.png)
![Screen Shot 2019-07-05 at 3 11 57 pm (2)](https://user-images.githubusercontent.com/127084/60699467-58012b00-9f37-11e9-9e27-3f1571941b26.png)
![Screen Shot 2019-07-05 at 3 12 02 pm (2)](https://user-images.githubusercontent.com/127084/60699468-58012b00-9f37-11e9-9d48-e7a80d979bd5.png)
![Screen Shot 2019-07-05 at 3 12 05 pm (2)](https://user-images.githubusercontent.com/127084/60699469-5899c180-9f37-11e9-9652-b00f010897ac.png)
![Screen Shot 2019-07-05 at 3 12 09 pm (2)](https://user-images.githubusercontent.com/127084/60699470-5899c180-9f37-11e9-8752-e3646b0e87e6.png)
