### PR TITLE
Change components to not require via root-level index

### DIFF
--- a/src/Autocomplete/Autocomplete.jsx
+++ b/src/Autocomplete/Autocomplete.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import withStyles from '@material-ui/core/styles/withStyles'
 
-import { TextField } from '../index'
+import TextField from '../TextField'
 
 function renderInput ({ InputProps, fullWidth, ref, ...other }) {
   const otherProps = { ...other, ...InputProps }

--- a/src/promo/ArticleDonationBanner.jsx
+++ b/src/promo/ArticleDonationBanner.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import withStyles from '@material-ui/core/styles/withStyles'
 import Paper from '@material-ui/core/Paper'
 import Typography from '../Typography'
-import { Button } from '../index'
+import Button from '../Button'
 
 const styles = theme => ({
   root: {

--- a/src/util.jsx
+++ b/src/util.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Grid } from './index'
+import Grid from '@material-ui/core/Grid'
 import get from 'lodash/get'
 
 const SPACING = 16


### PR DESCRIPTION
Upgrading MaterialUi v4 was more difficult than it needed to be because every test failed due to requiring from `./index.js`.

One problem in the index would propagate to every other spec, e.g.
A date picker had a legit failure, but we were seeing it fail in autocomplete, buttons, etc...