### PR TITLE
[526] Update @material-ui to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1387,8 +1387,7 @@
     "@emotion/hash": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.1.tgz",
-      "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==",
-      "dev": true
+      "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
     },
     "@emotion/is-prop-valid": {
       "version": "0.7.3",
@@ -1477,59 +1476,102 @@
       "dev": true
     },
     "@material-ui/core": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-3.9.1.tgz",
-      "integrity": "sha512-26GtjuwxPPfSsUnYrTOC8zuCuhWPVhc4SsUSFTZq0n1QvpGi9UEZRFe8yp6FykQE+PmqyyY+eWdrfiXKSUKZ0w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-kqwoCMpGaj3zJedihUuVZWjISh+T72KAXOwgk6VKNf+APMTB8yLByLSgSLDhXsliRBO/9Pda/0g/KzGY7R+irQ==",
       "requires": {
         "@babel/runtime": "^7.2.0",
-        "@material-ui/system": "^3.0.0-alpha.0",
-        "@material-ui/utils": "^3.0.0-alpha.2",
-        "@types/jss": "^9.5.6",
-        "@types/react-transition-group": "^2.0.8",
-        "brcast": "^3.0.1",
-        "classnames": "^2.2.5",
-        "csstype": "^2.5.2",
-        "debounce": "^1.1.0",
+        "@material-ui/styles": "^4.2.0",
+        "@material-ui/system": "^4.3.0",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.1.0",
+        "@types/react-transition-group": "^2.0.16",
+        "clsx": "^1.0.2",
+        "convert-css-length": "^2.0.0",
         "deepmerge": "^3.0.0",
-        "dom-helpers": "^3.2.1",
         "hoist-non-react-statics": "^3.2.1",
-        "is-plain-object": "^2.0.4",
-        "jss": "^9.8.7",
-        "jss-camel-case": "^6.0.0",
-        "jss-default-unit": "^8.0.2",
-        "jss-global": "^3.0.0",
-        "jss-nested": "^6.0.1",
-        "jss-props-sort": "^6.0.0",
-        "jss-vendor-prefixer": "^7.0.0",
-        "normalize-scroll-left": "^0.1.2",
+        "is-plain-object": "^3.0.0",
+        "normalize-scroll-left": "^0.2.0",
         "popper.js": "^1.14.1",
-        "prop-types": "^15.6.0",
-        "react-event-listener": "^0.6.2",
-        "react-transition-group": "^2.2.1",
-        "recompose": "0.28.0 - 0.30.0",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.0.0",
         "warning": "^4.0.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
           "requires": {
-            "regenerator-runtime": "^0.12.0"
+            "regenerator-runtime": "^0.13.2"
           }
         },
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+        "@material-ui/utils": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
+          "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
           "requires": {
-            "react-is": "^16.7.0"
+            "@babel/runtime": "^7.2.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
           }
+        },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "react-transition-group": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
+          "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
+          "requires": {
+            "@babel/runtime": "^7.4.5",
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         },
         "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
           "requires": {
             "loose-envify": "^1.0.0"
           }
@@ -1537,18 +1579,17 @@
       }
     },
     "@material-ui/icons": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-3.0.2.tgz",
-      "integrity": "sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.2.1.tgz",
+      "integrity": "sha512-FvSD5lUBJ66frI4l4AYAPy2CH14Zs2Dgm0o3oOMr33BdQtOAjCgbdOcvPBeaD1w6OQl31uNW3CKOE8xfPNxvUQ==",
       "requires": {
-        "@babel/runtime": "^7.2.0",
-        "recompose": "0.28.0 - 0.30.0"
+        "@babel/runtime": "^7.2.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.3.tgz",
-          "integrity": "sha512-9lsJwJLxDh/T3Q3SZszfWOTkk3pHbkmH+3KY+zwIDmsNlxsumuhS2TH3NIpktU4kNvfzy+k3eLT7aTJSPTo0OA==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -1561,23 +1602,93 @@
       }
     },
     "@material-ui/lab": {
-      "version": "3.0.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-3.0.0-alpha.30.tgz",
-      "integrity": "sha512-d8IXbkQO92Ln7f/Tzy8Q5cLi/sMWH/Uz1xrOO5NKUgg42whwyCuoT9ErddDPFNQmPi9d1C7A5AG8ONjEAbAIyQ==",
+      "version": "4.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.19.tgz",
+      "integrity": "sha512-DexeQ18rYF8s6RkTentk3IQd2l3Wmh1owHenPa7kNYfzJkZoiOKS+WRVPI8v/LGyNHcWHVjZ80+9sNRp6b9BTQ==",
       "requires": {
         "@babel/runtime": "^7.2.0",
-        "@material-ui/utils": "^3.0.0-alpha.2",
-        "classnames": "^2.2.5",
+        "@material-ui/utils": "^4.1.0",
+        "clsx": "^1.0.2",
         "keycode": "^2.1.9",
-        "prop-types": "^15.6.0"
+        "prop-types": "^15.7.2",
+        "warning": "^4.0.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
-          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@material-ui/pickers": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/pickers/-/pickers-3.1.2.tgz",
+      "integrity": "sha512-ij3w6s/FMgfEetywH7DB3YFgIZ7xezsT/RHlpoauAO8nvPDrYlRHK5sPOiDzxbjE9SB/t3aKkNZmYcs+sVd5ug==",
+      "requires": {
+        "@types/styled-jsx": "^2.2.8",
+        "clsx": "^1.0.2",
+        "react-transition-group": "^4.0.0",
+        "rifm": "^0.7.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "dom-helpers": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+          "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+          "requires": {
+            "@babel/runtime": "^7.1.2"
+          }
+        },
+        "react-transition-group": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
+          "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
+          "requires": {
+            "@babel/runtime": "^7.4.5",
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
           }
         },
         "regenerator-runtime": {
@@ -1587,52 +1698,183 @@
         }
       }
     },
-    "@material-ui/system": {
-      "version": "3.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-3.0.0-alpha.2.tgz",
-      "integrity": "sha512-odmxQ0peKpP7RQBQ8koly06YhsPzcoVib1vByVPBH4QhwqBXuYoqlCjt02846fYspAqkrWzjxnWUD311EBbxOA==",
+    "@material-ui/styles": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.2.0.tgz",
+      "integrity": "sha512-VpPCNWYK1KjpurFh1gH02xpAmCqKZrC/rmiBosZcCRDl8AOcUkSxBMNU0rziHgSQ/jYTEh3MdKNs3Gq0vGCQ/w==",
       "requires": {
         "@babel/runtime": "^7.2.0",
+        "@emotion/hash": "^0.7.1",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.1.0",
+        "clsx": "^1.0.2",
+        "csstype": "^2.5.2",
         "deepmerge": "^3.0.0",
-        "prop-types": "^15.6.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "jss": "10.0.0-alpha.17",
+        "jss-plugin-camel-case": "10.0.0-alpha.17",
+        "jss-plugin-default-unit": "10.0.0-alpha.17",
+        "jss-plugin-global": "10.0.0-alpha.17",
+        "jss-plugin-nested": "10.0.0-alpha.17",
+        "jss-plugin-props-sort": "10.0.0-alpha.17",
+        "jss-plugin-rule-value-function": "10.0.0-alpha.17",
+        "jss-plugin-vendor-prefixer": "10.0.0-alpha.17",
+        "prop-types": "^15.7.2",
         "warning": "^4.0.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
           "requires": {
-            "regenerator-runtime": "^0.12.0"
+            "regenerator-runtime": "^0.13.2"
           }
         },
+        "@material-ui/utils": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
+          "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
+          "requires": {
+            "@babel/runtime": "^7.2.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0"
+          }
+        },
+        "jss": {
+          "version": "10.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
         "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
           "requires": {
             "loose-envify": "^1.0.0"
           }
         }
       }
     },
-    "@material-ui/utils": {
-      "version": "3.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-3.0.0-alpha.3.tgz",
-      "integrity": "sha512-rwMdMZptX0DivkqBuC+Jdq7BYTXwqKai5G5ejPpuEDKpWzi1Oxp+LygGw329FrKpuKeiqpcymlqJTjmy+quWng==",
+    "@material-ui/system": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.3.0.tgz",
+      "integrity": "sha512-VQh3mWZSmzm1JR7Ci35AHKwOhhxHHMrBWCdP4mh7UAwSdjWBE6s2Y9Y0iJiqMoEsHP64vU3W1JpsW2AgkUeHsQ==",
       "requires": {
         "@babel/runtime": "^7.2.0",
-        "prop-types": "^15.6.0",
-        "react-is": "^16.6.3"
+        "deepmerge": "^3.0.0",
+        "prop-types": "^15.7.2",
+        "warning": "^4.0.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.3.1",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-          "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
           "requires": {
-            "regenerator-runtime": "^0.12.0"
+            "regenerator-runtime": "^0.13.2"
           }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "warning": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@material-ui/types": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
+      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@material-ui/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
       }
     },
@@ -2305,15 +2547,6 @@
         "loader-utils": "^1.1.0"
       }
     },
-    "@types/jss": {
-      "version": "9.5.7",
-      "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.7.tgz",
-      "integrity": "sha512-OZimStu2QdDMtZ0h72JXqvLVbWUjXd5ZLk8vxLmfuC/nM1AabRyyGoxSufnzixrbpEcVcyy/JV5qeQu2JnjVZw==",
-      "requires": {
-        "csstype": "^2.0.0",
-        "indefinite-observable": "^1.0.1"
-      }
-    },
     "@types/node": {
       "version": "10.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.0.tgz",
@@ -2340,18 +2573,18 @@
         "csstype": "^2.2.0"
       }
     },
-    "@types/react-text-mask": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@types/react-text-mask/-/react-text-mask-5.4.3.tgz",
-      "integrity": "sha512-+/uibOQ07X4om3+dPMpxUGdw76u4d4HQ9qCPs2syFtwmpTlnOyAJaIW89t+QX/DXI+Ar+SKch6A4stoLg5RdLw==",
+    "@types/react-transition-group": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.9.2.tgz",
+      "integrity": "sha512-5Fv2DQNO+GpdPZcxp2x/OQG/H19A01WlmpjVD9cKvVFmoVLOZ9LvBgSWG6pSXIU4og5fgbvGPaCV5+VGkWAEHA==",
       "requires": {
         "@types/react": "*"
       }
     },
-    "@types/react-transition-group": {
-      "version": "2.0.15",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.15.tgz",
-      "integrity": "sha512-S0QnNzbHoWXDbKBl/xk5dxA4FT+BNlBcI3hku991cl8Cz3ytOkUMcCRtzdX11eb86E131bSsQqy5WrPCdJYblw==",
+    "@types/styled-jsx": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@types/styled-jsx/-/styled-jsx-2.2.8.tgz",
+      "integrity": "sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==",
       "requires": {
         "@types/react": "*"
       }
@@ -2662,6 +2895,55 @@
         "string.prototype.padend": "^3.0.0",
         "string.prototype.padstart": "^3.0.0",
         "symbol.prototype.description": "^1.0.0"
+      }
+    },
+    "airbnb-prop-types": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
+      "integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
+      "dev": true,
+      "requires": {
+        "array.prototype.find": "^2.0.4",
+        "function.prototype.name": "^1.1.0",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.8.6"
+      },
+      "dependencies": {
+        "object.entries": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
+          "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.12.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+          "dev": true
+        }
       }
     },
     "ajv": {
@@ -3178,6 +3460,32 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "array.prototype.find": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.0.tgz",
+      "integrity": "sha512-Wn41+K1yuO5p7wRZDl7890c3xvv5UBrfVXTVIe28rSQb6LS0fZMDrQB6PAcxQFRFy6vJTLDc3A2+3CjQdzVKRg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.13.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+          "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-keys": "^1.0.12"
+          }
+        }
+      }
+    },
     "array.prototype.flat": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.1.tgz",
@@ -3209,7 +3517,8 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -4673,7 +4982,8 @@
     "change-emitter": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
-      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+      "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU=",
+      "dev": true
     },
     "character-entities": {
       "version": "1.2.2",
@@ -4700,58 +5010,34 @@
       "dev": true
     },
     "cheerio": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
-      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
       "dev": true,
       "requires": {
         "css-select": "~1.2.0",
-        "dom-serializer": "~0.1.0",
+        "dom-serializer": "~0.1.1",
         "entities": "~1.1.1",
         "htmlparser2": "^3.9.1",
         "lodash": "^4.15.0",
         "parse5": "^3.0.1"
       },
       "dependencies": {
+        "dom-serializer": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+          "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "entities": "^1.1.1"
+          }
+        },
         "domelementtype": {
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
           "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
           "dev": true
-        },
-        "domhandler": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "htmlparser2": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
-          "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
-          "dev": true,
-          "requires": {
-            "domelementtype": "^1.3.0",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^3.0.6"
-          }
-        },
-        "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
         }
       }
     },
@@ -4966,7 +5252,8 @@
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "dev": true
     },
     "clean-css": {
       "version": "4.2.1",
@@ -5208,6 +5495,11 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
+    "console-polyfill": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/console-polyfill/-/console-polyfill-0.1.2.tgz",
+      "integrity": "sha1-ls/tUcr3gYn2mVcubxgnHcN8DjA="
+    },
     "constants-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
@@ -5231,6 +5523,15 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
+    },
+    "convert-css-length": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.0.tgz",
+      "integrity": "sha512-ygBgHNzImHJ/kjgqdzC0oaY2+EMID3s88/CZD2C9O1stM3PwsOwXzzlFTTkZy/bPZe0wjyt1UoYjilfunQGjlw==",
+      "requires": {
+        "console-polyfill": "^0.1.2",
+        "parse-unit": "^1.0.1"
+      }
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -5635,11 +5936,6 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
-    "debounce": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
-    },
     "debug": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -5680,9 +5976,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.1.0.tgz",
-      "integrity": "sha512-/TnecbwXEdycfbsM2++O3eGiatEFHjjNciHEwJclM+T5Kd94qD1AP+2elP/Mq0L5b9VZJao5znR01Mz6eX8Seg=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
     },
     "default-require-extensions": {
       "version": "2.0.0",
@@ -5897,7 +6193,8 @@
     "dom-helpers": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==",
+      "dev": true
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -6178,6 +6475,7 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
       "requires": {
         "iconv-lite": "~0.4.13"
       }
@@ -6209,18 +6507,20 @@
       "dev": true
     },
     "enzyme": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.8.0.tgz",
-      "integrity": "sha512-bfsWo5nHyZm1O1vnIsbwdfhU989jk+squU9NKvB+Puwo5j6/Wg9pN5CO0YJelm98Dao3NPjkDZk+vvgwpMwYxw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.10.0.tgz",
+      "integrity": "sha512-p2yy9Y7t/PFbPoTvrWde7JIYB2ZyGC+NgTNbVEGvZ5/EyoYSr9aG/2rSbVvyNvMHEhw9/dmGUJHWtfQIEiX9pg==",
       "dev": true,
       "requires": {
         "array.prototype.flat": "^1.2.1",
         "cheerio": "^1.0.0-rc.2",
         "function.prototype.name": "^1.1.0",
         "has": "^1.0.3",
+        "html-element-map": "^1.0.0",
         "is-boolean-object": "^1.0.0",
         "is-callable": "^1.1.4",
         "is-number-object": "^1.0.3",
+        "is-regex": "^1.0.4",
         "is-string": "^1.0.4",
         "is-subset": "^0.1.1",
         "lodash.escape": "^4.0.1",
@@ -6236,18 +6536,19 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.8.0.tgz",
-      "integrity": "sha512-7cVHIKutqnesGeM3CjNFHSvktpypSWBokrBO8wIW+BVx+HGxWCF87W9TpkIIYJqgCtdw9FQGFrAbLg8kSwPRuQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz",
+      "integrity": "sha512-7PcOF7pb4hJUvjY7oAuPGpq3BmlCig3kxXGi2kFx0YzJHppqX1K8IIV9skT1IirxXlu8W7bneKi+oQ10QRnhcA==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "^1.10.0",
-        "function.prototype.name": "^1.1.0",
+        "enzyme-adapter-utils": "^1.12.0",
+        "has": "^1.0.3",
         "object.assign": "^4.1.0",
         "object.values": "^1.1.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.7.0",
-        "react-test-renderer": "^16.0.0-0"
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "react-test-renderer": "^16.0.0-0",
+        "semver": "^5.7.0"
       },
       "dependencies": {
         "object.values": {
@@ -6262,24 +6563,42 @@
             "has": "^1.0.3"
           }
         },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
         "react-is": {
-          "version": "16.7.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
-          "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==",
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true
         }
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.0.tgz",
-      "integrity": "sha512-VnIXJDYVTzKGbdW+lgK8MQmYHJquTQZiGzu/AseCZ7eHtOMAj4Rtvk8ZRopodkfPves0EXaHkXBDkVhPa3t0jA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.12.0.tgz",
+      "integrity": "sha512-wkZvE0VxcFx/8ZsBw0iAbk3gR1d9hK447ebnSYBf95+r32ezBq+XDSAvRErkc4LZosgH8J7et7H7/7CtUuQfBA==",
       "dev": true,
       "requires": {
+        "airbnb-prop-types": "^2.13.2",
         "function.prototype.name": "^1.1.0",
         "object.assign": "^4.1.0",
         "object.fromentries": "^2.0.0",
-        "prop-types": "^15.6.2",
+        "prop-types": "^15.7.2",
         "semver": "^5.6.0"
       },
       "dependencies": {
@@ -6294,6 +6613,23 @@
             "function-bind": "^1.1.1",
             "has": "^1.0.1"
           }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+          "dev": true
         }
       }
     },
@@ -7301,6 +7637,7 @@
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
       "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "dev": true,
       "requires": {
         "core-js": "^1.0.0",
         "isomorphic-fetch": "^2.1.1",
@@ -7314,7 +7651,8 @@
         "core-js": {
           "version": "1.2.7",
           "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
         }
       }
     },
@@ -8670,7 +9008,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
       "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -8680,6 +9017,23 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
+    },
+    "html-element-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
+      "integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      },
+      "dependencies": {
+        "array-filter": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+          "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+          "dev": true
+        }
+      }
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -8815,6 +9169,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -8901,14 +9256,6 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
-    },
-    "indefinite-observable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.2.tgz",
-      "integrity": "sha512-Mps0898zEduHyPhb7UCgNmfzlqNZknVmaFz5qzr0mm04YQ5FGLhAyK/dJ+NaRxGyR6juQXIxh5Ev0xx+qq0nYA==",
-      "requires": {
-        "symbol-observable": "1.2.0"
-      }
     },
     "indexes-of": {
       "version": "1.0.1",
@@ -9283,7 +9630,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-string": {
       "version": "1.0.4",
@@ -9346,6 +9694,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -9355,6 +9704,7 @@
           "version": "1.7.3",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
           "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
           "requires": {
             "encoding": "^0.1.11",
             "is-stream": "^1.0.1"
@@ -11684,6 +12034,261 @@
         "warning": "^3.0.0"
       }
     },
+    "jss-plugin-camel-case": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-aPY4kr6MwliH7KToLRzeSk1NxXUo9n7MQsAa0Hghwj01x9UnMkDkGAKENMKUtPjGkQZfiJpB9tTLFrSJ/6VrIQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "hyphenate-style-name": "^1.0.3",
+        "jss": "10.0.0-alpha.17"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "hyphenate-style-name": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+          "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+        },
+        "jss": {
+          "version": "10.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "jss-plugin-default-unit": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-KQgiXczvzJ9AlFdD8NS7FZLub0NSctSrCA9Yi/GqdsfJg4ZCriU4DzIybCZBHCi/INFGJmLIESYWSxnuhAzgSQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "jss": {
+          "version": "10.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "jss-plugin-global": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-WYxiwwI+CLk0ozW8loeceqXBAZXBMsLBEZeRwVf9WX+FljdJkGwVZpRCk6LBX4aXnqAGyKqCxIAIJ3KP2yBdEg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "jss": {
+          "version": "10.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "jss-plugin-nested": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-onpFqv904KCujryf2t6IIV1/QoB7cSF7ojrd4UujcN5TPvYOvXF5bchi7jnHG5U0SLlRSDGMLJ9fhtoCknhEbw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "jss": {
+          "version": "10.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "jss-plugin-props-sort": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-KnbyrxCbtQTqpDx2mSZU/r/E5QnDPIVfIxRi8K+W/q4gZpomBvqWC+xgvAk9hbpmA6QBoQaOilV8o12w2IZ6fg==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "jss": {
+          "version": "10.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "jss-plugin-rule-value-function": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-8AuJB44Q+ehfkWVRi2XlRbUf6SrLmrHTa5EXd6dgQRCCRuvGmqX8Dl4fZvNeKRFjTLPZgzg9+31rqeOMhKa2vA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "jss": "10.0.0-alpha.17"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "jss": {
+          "version": "10.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
+    "jss-plugin-vendor-prefixer": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-wDq9EL0QaoMGSGifPEBb+/SA9LBcqPEW0jpL9ht+Z2t+lV7NNz0j7uCEOuE6FvNWqHzUKTsiATs1rTHPkzNBEQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "css-vendor": "^2.0.1",
+        "jss": "10.0.0-alpha.17"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "css-vendor": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.5.tgz",
+          "integrity": "sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.0.2"
+          }
+        },
+        "jss": {
+          "version": "10.0.0-alpha.17",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+          "requires": {
+            "@babel/runtime": "^7.3.1",
+            "is-in-browser": "^1.1.3",
+            "tiny-warning": "^1.0.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
     "jss-preset-default": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.5.0.tgz",
@@ -12057,32 +12662,6 @@
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
       "dev": true
-    },
-    "material-ui-pickers": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/material-ui-pickers/-/material-ui-pickers-2.1.2.tgz",
-      "integrity": "sha512-e0E/oZ+ETceVX8Af3Z2K6L+MTy5JUVQ/qKSeFAY1d9sti0Ix6zMLwaNpg2WurpLnis32yUKjqzEqOGbOkaDQow==",
-      "requires": {
-        "@types/react-text-mask": "^5.4.3",
-        "clsx": "^1.0.1",
-        "react-event-listener": "^0.6.5",
-        "react-text-mask": "^5.4.3",
-        "react-transition-group": "^2.5.3",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "react-transition-group": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.3.tgz",
-          "integrity": "sha512-2DGFck6h99kLNr8pOFk+z4Soq3iISydwOFeeEVPjTN6+Y01CmvbWmnN02VuTWyFdnRtIDPe+wy2q6Ui8snBPZg==",
-          "requires": {
-            "dom-helpers": "^3.3.1",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        }
-      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -12476,9 +13055,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true
         }
       }
@@ -12657,9 +13236,9 @@
       "dev": true
     },
     "normalize-scroll-left": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
-      "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
+      "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -13127,6 +13706,11 @@
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
       }
+    },
+    "parse-unit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
+      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
     },
     "parse5": {
       "version": "3.0.3",
@@ -13680,6 +14264,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -13724,6 +14309,17 @@
       "requires": {
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
+      }
+    },
+    "prop-types-exact": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prop-types-exact/-/prop-types-exact-1.2.0.tgz",
+      "integrity": "sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "reflect.ownkeys": "^0.2.0"
       }
     },
     "property-information": {
@@ -14305,34 +14901,6 @@
       "integrity": "sha512-fp+U98OMZcnduQ+NSEiQa4s/XMsbp+5KlydmkbESOw4P69iWZ68ZMFM5a2BuE0FgqPBKApJyRuYHR95jM8lAmg==",
       "dev": true
     },
-    "react-event-listener": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.5.tgz",
-      "integrity": "sha512-//lCxOM3DQ0+xmTa/u9mI9mm55zCPdIKp89d8MGjlNsOOnXQ5sFDD1eed+sMBzQXKiRBLBMtSg/2T9RJFtfovw==",
-      "requires": {
-        "@babel/runtime": "7.2.0",
-        "prop-types": "^15.6.0",
-        "warning": "^4.0.1"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-          "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
-          "requires": {
-            "regenerator-runtime": "^0.12.0"
-          }
-        },
-        "warning": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-          "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
     "react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
@@ -14419,7 +14987,8 @@
     "react-lifecycles-compat": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "dev": true
     },
     "react-modal": {
       "version": "3.8.1",
@@ -14536,31 +15105,23 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.7.0.tgz",
-      "integrity": "sha512-tFbhSjknSQ6+ttzmuGdv+SjQfmvGcq3PFKyPItohwhhOBmRoTf1We3Mlt3rJtIn85mjPXOkKV+TaKK4irvk9Yg==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",
+      "integrity": "sha512-H2srzU5IWYT6cZXof6AhUcx/wEyJddQ8l7cLM/F7gDXYyPr4oq+vCIxJYXVGhId1J706sqziAjuOEjyNkfgoEw==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.7.0",
-        "scheduler": "^0.12.0"
+        "react-is": "^16.8.6",
+        "scheduler": "^0.13.6"
       },
       "dependencies": {
         "react-is": {
-          "version": "16.7.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.7.0.tgz",
-          "integrity": "sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==",
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
           "dev": true
         }
-      }
-    },
-    "react-text-mask": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/react-text-mask/-/react-text-mask-5.4.3.tgz",
-      "integrity": "sha1-mR77QpnjDC5sLEbRP2FxaUY+DS0=",
-      "requires": {
-        "prop-types": "^15.5.6"
       }
     },
     "react-textarea-autosize": {
@@ -14577,6 +15138,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
       "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
+      "dev": true,
       "requires": {
         "dom-helpers": "^3.3.1",
         "loose-envify": "^1.4.0",
@@ -15030,6 +15592,7 @@
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.30.0.tgz",
       "integrity": "sha512-ZTrzzUDa9AqUIhRk4KmVFihH0rapdCSMFXjhHbNrjAWxBuUD/guYlyysMnuHjlZC/KRiOKRtB4jf96yYSkKE8w==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.0.0",
         "change-emitter": "^0.1.2",
@@ -15042,7 +15605,8 @@
         "hoist-non-react-statics": {
           "version": "2.5.5",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+          "dev": true
         }
       }
     },
@@ -15054,6 +15618,12 @@
       "requires": {
         "minimatch": "3.0.4"
       }
+    },
+    "reflect.ownkeys": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
+      "integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
+      "dev": true
     },
     "refractor": {
       "version": "2.8.0",
@@ -15482,6 +16052,29 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
+    "rifm": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/rifm/-/rifm-0.7.0.tgz",
+      "integrity": "sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==",
+      "requires": {
+        "@babel/runtime": "^7.3.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
+          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
+      }
+    },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -15574,7 +16167,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "3.1.0",
@@ -15939,9 +16533,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
-      "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
       "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
@@ -16081,7 +16675,8 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "setprototypeof": {
       "version": "1.1.0",
@@ -17045,8 +17640,7 @@
     "tiny-warning": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
-      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q==",
-      "dev": true
+      "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
     },
     "tinycolor2": {
       "version": "1.4.1",
@@ -17264,7 +17858,8 @@
     "ua-parser-js": {
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==",
+      "dev": true
     },
     "uglify-js": {
       "version": "3.4.9",
@@ -17855,7 +18450,8 @@
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "url": "git+ssh://git@github.com/conversation/ui.git"
   },
   "dependencies": {
-    "@material-ui/core": "^3.9.1",
-    "@material-ui/icons": "^3.0.2",
-    "@material-ui/lab": "^3.0.0-alpha.30",
+    "@material-ui/core": "^4.2.0",
+    "@material-ui/icons": "^4.2.0",
+    "@material-ui/lab": "^4.0.0-alpha.19",
+    "@material-ui/pickers": "^3.1.2",
     "downshift": "^3.1.5",
     "lodash": "^4.17.11",
-    "material-ui-pickers": "^2.1.2",
     "react-jss": "^8.6.1"
   },
   "devDependencies": {

--- a/src/Autocomplete/Autocomplete.jsx
+++ b/src/Autocomplete/Autocomplete.jsx
@@ -79,7 +79,7 @@ const styles = theme => {
     paper: {
       position: 'absolute',
       zIndex: 1,
-      marginTop: theme.spacing.unit,
+      marginTop: theme.spacing(1),
       left: 0,
       right: 0
     },

--- a/src/Autocomplete/Autocomplete.test.jsx
+++ b/src/Autocomplete/Autocomplete.test.jsx
@@ -90,7 +90,7 @@ describe('<Autocomplete />', () => {
         wrapper.find('input').simulate('change', { target: { value: 'aus' } })
 
         // Choose the suggestion.
-        wrapper.find('MenuItem').simulate('click')
+        wrapper.find('ForwardRef(MenuItem)').simulate('click')
 
         expect(onChange).toHaveBeenCalledWith({ value: 'AU', label: 'Australia' })
       })

--- a/src/ChipInput/ChipInput.jsx
+++ b/src/ChipInput/ChipInput.jsx
@@ -19,14 +19,14 @@ const styles = theme => {
       display: 'flex',
       justifyContent: 'center',
       flexWrap: 'wrap',
-      padding: theme.spacing.unit / 2
+      padding: theme.spacing(1) / 2
     },
     label: {
       marginTop: 8,
-      marginBottom: theme.spacing.unit
+      marginBottom: theme.spacing(1)
     },
     chip: {
-      margin: theme.spacing.unit / 2
+      margin: theme.spacing(1) / 2
     },
     error: {
       borderColor: theme.palette.error.border
@@ -42,7 +42,7 @@ const styles = theme => {
       borderColor: borderColor
     },
     inputRoot: {
-      margin: theme.spacing.unit / 2
+      margin: theme.spacing(1) / 2
     },
     chipContainer: {
       borderStyle: 'solid',

--- a/src/ChipInput/ChipInput.test.jsx
+++ b/src/ChipInput/ChipInput.test.jsx
@@ -65,7 +65,7 @@ describe('<ChipInput />', () => {
     const tree = mount(
       <ChipInput entries={['foo', 'bar']} onChange={handleChange} />
     )
-    tree.find('Cancel').first().simulate('click')
+    tree.find('ForwardRef(SvgIcon)').first().simulate('click')
     expect(handleChange).toBeCalledWith([{ 'valid': true, 'value': 'bar' }])
   })
 

--- a/src/ChipInput/ChipInput.test.jsx
+++ b/src/ChipInput/ChipInput.test.jsx
@@ -11,7 +11,7 @@ describe('<ChipInput />', () => {
     const tree = mount(
       <ChipInput entries={['foo', 'bar', 'foobar']} />
     )
-    expect(tree.find('Chip').map((chip) => chip.text())).toEqual(['foo', 'bar', 'foobar'])
+    expect(tree.find('ForwardRef(Chip)').map((chip) => chip.text())).toEqual(['foo', 'bar', 'foobar'])
   })
 
   it('displays added chips', () => {
@@ -20,7 +20,7 @@ describe('<ChipInput />', () => {
     )
     tree.find('input').getDOMNode().value = 'test'
     tree.find('input').simulate('keyDown', { keyCode: 13 }) // press enter
-    expect(tree.find('Chip').map((chip) => chip.text())).toEqual(['foo', 'bar', 'test'])
+    expect(tree.find('ForwardRef(Chip)').map((chip) => chip.text())).toEqual(['foo', 'bar', 'test'])
   })
 
   it('calls onChange when adding new chips', () => {
@@ -182,18 +182,18 @@ describe('<ChipInput />', () => {
 
   describe('chip focusing', () => {
     function getFocusedChip (tree) {
-      return tree.find('Chip').filterWhere((chip) => chip.getDOMNode().style.backgroundColor !== 'rgb(100, 181, 246)')
+      return tree.find('ForwardRef(Chip)').filterWhere((chip) => chip.getDOMNode().style.backgroundColor !== 'rgb(100, 181, 246)')
     }
 
     function focusChip (tree, name) {
-      tree.find('Chip').filterWhere((chip) => chip.text() === name).simulate('click')
+      tree.find('ForwardRef(Chip)').filterWhere((chip) => chip.text() === name).simulate('click')
     }
 
     it('focuses a chip on click', () => {
       const tree = mount(
         <ChipInput entries={['foo', 'bar']} />
       )
-      tree.find('Chip').at(1).simulate('click')
+      tree.find('ForwardRef(Chip)').at(1).simulate('click')
       expect(getFocusedChip(tree).length).toBe(1)
       expect(getFocusedChip(tree).text()).toBe('bar')
     })

--- a/src/ComponentOverview.jsx
+++ b/src/ComponentOverview.jsx
@@ -26,8 +26,8 @@ const PropDefinitionsTable = ({ propDefinitions }) => (
       </tr>
     </thead>
     <tbody>
-      {propDefinitions.map(propDefinition =>
-        <Row {...propDefinition} />
+      {propDefinitions.map((propDefinition, index) =>
+        <Row key={index} {...propDefinition} />
       )}
     </tbody>
   </table>

--- a/src/Typography/stories/variants.jsx
+++ b/src/Typography/stories/variants.jsx
@@ -26,6 +26,13 @@ You can set the variant of the text using the \`variant\` prop:
 
 export default withDocs(md, () =>
   VARIANTS.map((variant, index) =>
-    <Typography gutterBottom key={index} variant={variant}>{variant}. {LIPSUM}</Typography>
+    <Typography
+      gutterBottom
+      display='block'
+      key={index}
+      variant={variant}
+    >
+      {variant}.{LIPSUM}
+    </Typography>
   )
 )

--- a/src/divider/MiniDivider.jsx
+++ b/src/divider/MiniDivider.jsx
@@ -4,7 +4,7 @@ import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({
   root: {
-    margin: `${theme.spacing.unit * 2}px auto`,
+    margin: `${theme.spacing(1) * 2}px auto`,
     width: '21px',
     backgroundColor: theme.palette.primary.contrastText
   }

--- a/src/form/FormLabel.jsx
+++ b/src/form/FormLabel.jsx
@@ -3,6 +3,7 @@ import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({
   root: {
+    fontFamily: 'Noto Sans',
     fontWeight: 'bold',
     fontSize: theme.typography.pxToRem(12),
     textAlign: 'left'

--- a/src/pickers/DatePicker/DatePicker.jsx
+++ b/src/pickers/DatePicker/DatePicker.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { DatePicker as MaterialDatePicker, MuiPickersUtilsProvider } from 'material-ui-pickers'
+import { DatePicker as MaterialDatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers'
 
 /**
  * The `<DatePicker>` component allows a user to easily select a specific date.

--- a/src/pickers/DatePicker/DatePicker.test.jsx
+++ b/src/pickers/DatePicker/DatePicker.test.jsx
@@ -29,7 +29,9 @@ describe('<DatePicker />', () => {
       )
 
       wrapper.find('input').simulate('click')
-      wrapper.find(Button, { children: 'OK' }).at(1).simulate('click')
+
+      const okButton = wrapper.find(Button).findWhere(b => b.text() === 'OK').first()
+      okButton.simulate('click')
 
       expect(onChange).toHaveBeenCalled()
     })

--- a/src/pickers/DatePicker/DatePicker.test.jsx
+++ b/src/pickers/DatePicker/DatePicker.test.jsx
@@ -1,7 +1,7 @@
 import Button from '@material-ui/core/Button'
 import MomentUtils from '@date-io/moment'
 import React from 'react'
-import { DatePicker as MaterialDatePicker, MuiPickersUtilsProvider } from 'material-ui-pickers'
+import { DatePicker as MaterialDatePicker, MuiPickersUtilsProvider } from '@material-ui/pickers'
 import { mount, shallow } from 'enzyme'
 
 import DatePicker from './DatePicker'

--- a/src/pickers/DateTimePicker/DateTimePicker.jsx
+++ b/src/pickers/DateTimePicker/DateTimePicker.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { DateTimePicker as MaterialDateTimePicker, MuiPickersUtilsProvider } from 'material-ui-pickers'
+import { DateTimePicker as MaterialDateTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers'
 
 /**
  * The `<DateTimePicker>` component allows a user to easily select a specific date and time of the day.

--- a/src/pickers/DateTimePicker/DateTimePicker.test.jsx
+++ b/src/pickers/DateTimePicker/DateTimePicker.test.jsx
@@ -1,7 +1,7 @@
 import Button from '@material-ui/core/Button'
 import MomentUtils from '@date-io/moment'
 import React from 'react'
-import { DateTimePicker as MaterialDateTimePicker, MuiPickersUtilsProvider } from 'material-ui-pickers'
+import { DateTimePicker as MaterialDateTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers'
 import { mount, shallow } from 'enzyme'
 
 import DateTimePicker from './DateTimePicker'

--- a/src/pickers/DateTimePicker/DateTimePicker.test.jsx
+++ b/src/pickers/DateTimePicker/DateTimePicker.test.jsx
@@ -29,7 +29,9 @@ describe('<DateTimePicker />', () => {
       )
 
       wrapper.find('input').simulate('click')
-      wrapper.find(Button, { children: 'OK' }).at(1).simulate('click')
+
+      const okButton = wrapper.find(Button).findWhere(b => b.text() === 'OK').first()
+      okButton.simulate('click')
 
       expect(onChange).toHaveBeenCalled()
     })

--- a/src/pickers/TimePicker/TimePicker.jsx
+++ b/src/pickers/TimePicker/TimePicker.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { TimePicker as MaterialTimePicker, MuiPickersUtilsProvider } from 'material-ui-pickers'
+import { TimePicker as MaterialTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers'
 
 /**
  * The `<TimePicker>` component allows a user to easily select a specific time of the day.

--- a/src/pickers/TimePicker/TimePicker.test.jsx
+++ b/src/pickers/TimePicker/TimePicker.test.jsx
@@ -29,7 +29,8 @@ describe('<TimePicker />', () => {
       )
 
       wrapper.find('input').simulate('click')
-      wrapper.find(Button, { children: 'OK' }).at(1).simulate('click')
+      const okButton = wrapper.find(Button).findWhere(b => b.text() === 'OK').first()
+      okButton.simulate('click')
 
       expect(onChange).toHaveBeenCalled()
     })

--- a/src/pickers/TimePicker/TimePicker.test.jsx
+++ b/src/pickers/TimePicker/TimePicker.test.jsx
@@ -1,7 +1,7 @@
 import Button from '@material-ui/core/Button'
 import MomentUtils from '@date-io/moment'
 import React from 'react'
-import { TimePicker as MaterialDateTimePicker, MuiPickersUtilsProvider } from 'material-ui-pickers'
+import { TimePicker as MaterialDateTimePicker, MuiPickersUtilsProvider } from '@material-ui/pickers'
 import { mount, shallow } from 'enzyme'
 
 import TimePicker from './TimePicker'

--- a/src/promo/ArticleDonationBanner.jsx
+++ b/src/promo/ArticleDonationBanner.jsx
@@ -8,7 +8,7 @@ import Button from '../Button'
 const styles = theme => ({
   root: {
     backgroundColor: '#f8f8f8',
-    padding: theme.spacing.unit * 3
+    padding: theme.spacing(3)
   },
   // TODO: this is temporary while we work out what to do about
   // themes and palettes properly

--- a/src/promo/ArticleDonationBanner.test.jsx
+++ b/src/promo/ArticleDonationBanner.test.jsx
@@ -1,3 +1,8 @@
+/**
+ * @jest-environment node
+ * https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85#gistcomment-2911761
+ */
+
 import React from 'react'
 import { shallow } from 'enzyme'
 

--- a/src/promo/DonationBanner.jsx
+++ b/src/promo/DonationBanner.jsx
@@ -15,18 +15,18 @@ const styles = theme => ({
     backgroundColor: theme.palette.core && theme.palette.core.main,
     color: theme.palette.primary.contrastText,
     borderRadius: 0,
-    padding: theme.spacing.unit * 4,
+    padding: theme.spacing(4),
     textAlign: 'center'
   },
   close: {
     position: 'absolute',
     top: 0,
     right: 0,
-    margin: theme.spacing.unit
+    margin: theme.spacing(1)
   },
   typography: {
-    maxWidth: theme.spacing.unit * 90,
-    padding: `0 ${theme.spacing.unit * 4}px`, // ensure there's always room for close button
+    maxWidth: theme.spacing(90),
+    padding: `0 ${theme.spacing(4)}px`, // ensure there's always room for close button
     marginLeft: 'auto',
     marginRight: 'auto'
   },

--- a/src/promo/DonationDialog.jsx
+++ b/src/promo/DonationDialog.jsx
@@ -30,7 +30,7 @@ const styles = theme => ({
     backgroundColor: theme.palette.core && theme.palette.core.main,
     overflow: 'visible', // So we can have the avatar poking out the top
     color: theme.palette.primary.contrastText,
-    margin: `48px ${theme.spacing.unit * 3}px`,
+    margin: `48px ${theme.spacing(3)}px`,
     textAlign: 'center',
 
     // For small devices, allow the dialog paper to be full width/height.
@@ -50,10 +50,10 @@ const styles = theme => ({
   bottomActions: {
     justifyContent: 'center',
     marginTop: 0,
-    marginBottom: theme.spacing.unit * 6
+    marginBottom: theme.spacing(6)
   },
   close: {
-    margin: theme.spacing.unit
+    margin: theme.spacing(1)
   },
   // Donation button styles are a special case until we decide
   // "inverted" buttons are going to be a more widespread thing

--- a/src/promo/ThinBanner.jsx
+++ b/src/promo/ThinBanner.jsx
@@ -13,7 +13,7 @@ const styles = theme => ({
   },
   icon: {
     position: 'absolute',
-    right: theme.spacing.unit
+    right: theme.spacing(1)
   }
 })
 

--- a/src/promo/ThinDonationBanner.jsx
+++ b/src/promo/ThinDonationBanner.jsx
@@ -22,7 +22,7 @@ const styles = theme => ({
   },
   icon: {
     position: 'absolute',
-    right: theme.spacing.unit
+    right: theme.spacing(1)
   }
 })
 

--- a/src/styles/ThemeProvider.jsx
+++ b/src/styles/ThemeProvider.jsx
@@ -7,9 +7,9 @@ import defaultTheme from './themes/default'
 
 const theme = defaultTheme()
 
-const ThemeProvider = ({ children, sheetsManager, sheetsRegistry, generateClassName, ...other }) => (
+const ThemeProvider = ({ children, sheetsRegistry, generateClassName, ...other }) => (
   <JssProvider registry={sheetsRegistry} generateClassName={generateClassName} >
-    <MuiThemeProvider theme={theme} sheetsManager={sheetsManager} {...other} >
+    <MuiThemeProvider theme={theme} {...other} >
       {children}
     </MuiThemeProvider>
   </JssProvider>
@@ -20,11 +20,6 @@ ThemeProvider.propTypes = {
    * The child components to which the theme will be applied.
    */
   children: PropTypes.node.isRequired,
-
-  /**
-   * A `sheetsManager` is used to handle stylesheet injection in the page.
-   */
-  sheetsManager: PropTypes.object,
 
   /**
    * A `sheetsRegistry` is used to keep track of the stylesheet.

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -1,10 +1,6 @@
 import core from '../palettes/core'
 
 export const typography = {
-  // Enable v2 variants.
-  // https://material-ui.com/style/typography/#migration-to-typography-v2
-  useNextVariants: true,
-
   fontFamily: 'Noto Sans',
 
   h1: { fontFamily: 'Montserrat', fontWeight: 700 },

--- a/src/util.jsx
+++ b/src/util.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Grid from '@material-ui/core/Grid'
 import get from 'lodash/get'
 
-const SPACING = 16
+const SPACING = 2
 
 /**
  * The `<GridLayout>` component automatically renders its children in a grid


### PR DESCRIPTION
https://trello.com/c/OCkepBuq/526-update-materialui-to-420

To unblock https://github.com/conversation/ui/pull/78, @nickbrowne and I went about upgrading TCUI to use `@material-ui/core` to 4.2.0.

We also found that we had to upgrade `@material-ui/icons` and `@material-ui/lab` (due to peer dependencies), and `material-ui-pickers` was merged into MterialUI to become`@material-ui/pickers`.