### PR TITLE
Lock material-ui/core to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,25 +1579,25 @@
       }
     },
     "@material-ui/icons": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.2.1.tgz",
-      "integrity": "sha512-FvSD5lUBJ66frI4l4AYAPy2CH14Zs2Dgm0o3oOMr33BdQtOAjCgbdOcvPBeaD1w6OQl31uNW3CKOE8xfPNxvUQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.2.0.tgz",
+      "integrity": "sha512-v+rz61KzH+qR8x17BrfOF73f75x+wUNiBhv9tsKnEed+ElROMK2dqfMAlsdgEP+wgGl4VOcxzUQqWHcaApZ+CA==",
       "requires": {
         "@babel/runtime": "^7.2.0"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.5.1",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.1.tgz",
-          "integrity": "sha512-g+hmPKs16iewFSmW57NkH9xpPkuYD1RV3UE2BCkXx9j+nhhRb9hsiSxPmEa67j35IecTQdn4iyMtHMbt5VoREg==",
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
+          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.2",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "url": "git+ssh://git@github.com/conversation/ui.git"
   },
   "dependencies": {
-    "@material-ui/core": "^4.2.0",
-    "@material-ui/icons": "^4.2.0",
+    "@material-ui/core": "4.2.0",
+    "@material-ui/icons": "4.2.0",
     "@material-ui/lab": "^4.0.0-alpha.19",
-    "@material-ui/pickers": "^3.1.2",
-    "downshift": "^3.1.5",
-    "lodash": "^4.17.11",
-    "react-jss": "^8.6.1"
+    "@material-ui/pickers": "3.1.2",
+    "downshift": "3.2.7",
+    "lodash": "4.17.11",
+    "react-jss": "8.6.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",


### PR DESCRIPTION
https://trello.com/c/SZC5hsy6/783-lock-tcui-to-material-ui-core-420

This PR locks `@material-ui/core` to 4.2.0 and downshift to 3.2.7, and sets specific versions to material-ui related packages.

@nickbrowne and I looked at a js package upgrade on TC. on TC, Most of the changes came from TCUI. This PR locks those versions down (removes the `^`).

Then, upgrades should be by a choice, and then pushed to TC.
When we bump material-ui/core to 4.3.2 in a future PR, downshift needs to upgrade to v4.0.0 then.