### PR TITLE
Show more examples of MessageTile components + enhance MessageTile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Move ThinBanner and ThickBanner to top level, outside promos.
+* Added props to MessageTile to allow it to be more configurable
+* Added more examples of MessageTile
 
 # 2.12.0 (2019-08-26)
 

--- a/src/MessageTile/MessageTileButton.jsx
+++ b/src/MessageTile/MessageTileButton.jsx
@@ -9,9 +9,9 @@ const styles = theme => ({
   }
 })
 
-export const MessageTileButton = ({ children, fullWidth, prominent, classes, onClick }) => {
+export const MessageTileButton = ({ children, classes, ...props }) => {
   return (
-    <Button fullWidth={fullWidth} prominent={prominent} className={classes.button} colour='primary' onClick={onClick}>
+    <Button className={classes.button} colour='primary' {...props}>
       {children}
     </Button>
   )
@@ -24,17 +24,9 @@ MessageTileButton.propTypes = {
    */
   children: PropTypes.node.isRequired,
   /**
-   * The onClick event for the Button
+   *
    */
-  onClick: PropTypes.func,
-  /**
-   * If the button should run full width
-   */
-  fullWidth: PropTypes.bool,
-  /**
-   * If the button should be a little wider, having extra padding left and right
-   */
-  prominent: PropTypes.bool
+  classes: PropTypes.object
 }
 
 MessageTileButton.defaultProps = {

--- a/src/MessageTile/MessageTileButton.jsx
+++ b/src/MessageTile/MessageTileButton.jsx
@@ -9,9 +9,9 @@ const styles = theme => ({
   }
 })
 
-export const MessageTileButton = ({ children, classes, onClick }) => {
+export const MessageTileButton = ({ children, fullWidth, prominent, classes, onClick }) => {
   return (
-    <Button fullWidth className={classes.button} colour='primary' onClick={onClick}>
+    <Button fullWidth={fullWidth} prominent={prominent} className={classes.button} colour='primary' onClick={onClick}>
       {children}
     </Button>
   )
@@ -26,7 +26,20 @@ MessageTileButton.propTypes = {
   /**
    * The onClick event for the Button
    */
-  onClick: PropTypes.func
+  onClick: PropTypes.func,
+  /**
+   * If the button should run full width
+   */
+  fullWidth: PropTypes.bool,
+  /**
+   * If the button should be a little wider, having extra padding left and right
+   */
+  prominent: PropTypes.bool
+}
+
+MessageTileButton.defaultProps = {
+  fullWidth: true,
+  prominent: false
 }
 
 export default withStyles(styles)(MessageTileButton)

--- a/src/MessageTile/stories/examples.jsx
+++ b/src/MessageTile/stories/examples.jsx
@@ -1,0 +1,137 @@
+import React from 'react'
+import { ThemeProvider } from '../../styles'
+import Typography from '../../Typography'
+import MessageTile from '../MessageTile'
+import MessageTileHeader from '../MessageTileHeader'
+import MessageTileBody from '../MessageTileBody'
+import MessageTileButton from '../MessageTileButton'
+import { action } from '@storybook/addon-actions'
+
+import Avatar from '../../Avatar'
+import Person from '../../Person'
+
+import by from './by.svg'
+import cc from './cc.svg'
+import nd from './nd.svg'
+
+import accentTheme from '../../styles/themes/accent'
+import coreTheme from '../../styles/themes/core'
+import defaultTheme from '../../styles/themes/default'
+
+export default () => (
+  <div>
+    <Typography
+      style={{ clear: 'both', margin: '20px 0' }}
+      variant='h4'
+    >
+      Republishing
+    </Typography>
+
+    <div style={{ width: 220 }}>
+      <ThemeProvider theme={defaultTheme()}>
+        <MessageTile>
+          <MessageTileHeader>
+            <img style={{ width: 26, marginRight: 6, marginBottom: 8 }} src={by} />
+            <img style={{ width: 26, marginRight: 6, marginBottom: 8 }} src={cc} />
+            <img style={{ width: 26, marginBottom: 8 }} src={nd} />
+            <div>We believe in the free flow of information.</div>
+          </MessageTileHeader>
+
+          <MessageTileBody>
+            All our articles can be republished for free, online or in print, under the Creative Commons licence.
+          </MessageTileBody>
+
+          <MessageTileButton onClick={action('clicked')}>
+            Republish for free
+          </MessageTileButton>
+        </MessageTile>
+      </ThemeProvider>
+    </div>
+
+    <Typography
+      style={{ clear: 'both', margin: '20px 0' }}
+      variant='h4'
+    >
+      Donations
+    </Typography>
+
+    <div style={{ width: 220 }}>
+      <ThemeProvider theme={coreTheme()}>
+        <MessageTile>
+          <MessageTileHeader>
+            Support The Conversation. Please donate.
+          </MessageTileHeader>
+
+          <MessageTileBody>
+            We provide clean information in a world infected with spin.
+          </MessageTileBody>
+
+          <MessageTileButton onClick={action('clicked')}>
+            Donate now
+          </MessageTileButton>
+        </MessageTile>
+      </ThemeProvider>
+    </div>
+
+    <Typography
+      style={{ clear: 'both', margin: '20px 0' }}
+      variant='h4'
+    >
+      End of article donation call-to-actions
+    </Typography>
+
+    <div style={{ width: 552 }}>
+      <ThemeProvider theme={coreTheme()}>
+        <MessageTile>
+          <MessageTileHeader>
+            Before you go...
+          </MessageTileHeader>
+
+          <MessageTileBody>
+            <Typography variant='body1' paragraph>
+              It is easier than ever before for vested interests to spread
+              disinformation on vital matters of public interest. If you want
+              to know what's really going you need to hear from the experts
+              willing to drill down to the truth. But we can't do that vital
+              work unless readers donate. Please make a donation.
+            </Typography>
+          </MessageTileBody>
+
+          <MessageTileButton fullWidth={false} prominent onClick={action('clicked')}>
+            Donate now
+          </MessageTileButton>
+
+          <div key='attribution'>
+            <Typography gutterBottom>
+              <Person name='Misha Ketchell' caption='Editor' />
+            </Typography>
+            <Avatar size={48} src='https://cdn.theconversation.com/avatars/13/width238/image-20181205-186070-f58pk2.jpg' />
+          </div>
+        </MessageTile>
+      </ThemeProvider>
+    </div>
+
+    <Typography
+      style={{ clear: 'both', margin: '20px 0' }}
+      variant='h4'
+    >
+      Newsletter Subscriptions
+    </Typography>
+
+    <div style={{ width: 400 }}>
+      <ThemeProvider theme={accentTheme()}>
+        <MessageTile>
+          <MessageTileHeader>
+            Want to follow The Conversation?
+          </MessageTileHeader>
+          <MessageTileBody>
+            Subscribe to our daily newsletter and get the latest analysis and commentary directly in your inbox.
+          </MessageTileBody>
+          <MessageTileButton onClick={action('clicked')}>
+            Subscribe now
+          </MessageTileButton>
+        </MessageTile>
+      </ThemeProvider>
+    </div>
+  </div>
+)

--- a/src/MessageTile/stories/index.jsx
+++ b/src/MessageTile/stories/index.jsx
@@ -1,11 +1,13 @@
 import { storiesOf } from '@storybook/react'
 import messageTile from './messageTile'
+import examples from './examples'
 import messageTileHeader from './messageTileHeader'
 import messageTileBody from './messageTileBody'
 import messageTileButton from './messageTileButton'
 
 storiesOf('MessageTile', module)
   .add('Overview', messageTile)
+  .add('Examples', examples)
   .add('MessageTileHeader', messageTileHeader)
   .add('MessageTileBody', messageTileBody)
   .add('MessageTileButton', messageTileButton)

--- a/src/MessageTile/stories/messageTile.jsx
+++ b/src/MessageTile/stories/messageTile.jsx
@@ -15,7 +15,7 @@ import defaultTheme from '../../styles/themes/default'
 
 export default () => (
   <ComponentOverview heading='MessageTile' component={UnwrappedMessageTile}>
-    <div style={{ marginTop: 20, width: 220 }}>
+    <div style={{ marginTop: 16, width: 220 }}>
       <ThemeProvider theme={defaultTheme()}>
         <MessageTile>
           <MessageTileHeader>

--- a/src/MessageTile/stories/messageTile.jsx
+++ b/src/MessageTile/stories/messageTile.jsx
@@ -1,7 +1,6 @@
 import ComponentOverview from '../../ComponentOverview'
 import React from 'react'
 import { ThemeProvider } from '../../styles'
-import Typography from '../../Typography'
 import MessageTile, { MessageTile as UnwrappedMessageTile } from '../MessageTile'
 import MessageTileHeader from '../MessageTileHeader'
 import MessageTileBody from '../MessageTileBody'
@@ -12,13 +11,11 @@ import by from './by.svg'
 import cc from './cc.svg'
 import nd from './nd.svg'
 
-import accentTheme from '../../styles/themes/accent'
-import coreTheme from '../../styles/themes/core'
 import defaultTheme from '../../styles/themes/default'
 
 export default () => (
   <ComponentOverview heading='MessageTile' component={UnwrappedMessageTile}>
-    <div style={{ width: 220 }}>
+    <div style={{ marginTop: 20, width: 220 }}>
       <ThemeProvider theme={defaultTheme()}>
         <MessageTile>
           <MessageTileHeader>
@@ -37,54 +34,6 @@ export default () => (
           </MessageTileButton>
         </MessageTile>
       </ThemeProvider>
-
-      <Typography
-        style={{ clear: 'both', margin: '20px 0' }}
-        variant='h4'
-      >
-        Core Theme
-      </Typography>
-
-      <div style={{ width: 220 }}>
-        <ThemeProvider theme={coreTheme()}>
-          <MessageTile>
-            <MessageTileHeader>
-              Support The Conversation. Please donate.
-            </MessageTileHeader>
-
-            <MessageTileBody>
-              We provide clean information in a world infected with spin.
-            </MessageTileBody>
-
-            <MessageTileButton onClick={action('clicked')}>
-              Donate now
-            </MessageTileButton>
-          </MessageTile>
-        </ThemeProvider>
-      </div>
-
-      <Typography
-        style={{ clear: 'both', margin: '20px 0' }}
-        variant='h4'
-      >
-        Accent Theme
-      </Typography>
-
-      <div style={{ width: 400 }}>
-        <ThemeProvider theme={accentTheme()}>
-          <MessageTile>
-            <MessageTileHeader>
-              Want to follow The Conversation?
-            </MessageTileHeader>
-            <MessageTileBody>
-              Subscribe to our daily newsletter and get the latest analysis and commentary directly in your inbox.
-            </MessageTileBody>
-            <MessageTileButton onClick={action('clicked')}>
-              Subscribe now
-            </MessageTileButton>
-          </MessageTile>
-        </ThemeProvider>
-      </div>
     </div>
   </ComponentOverview>
 )


### PR DESCRIPTION
https://trello.com/c/QhX47tvY/991-show-more-examples-of-messagetile-components

A point raised in a team meeting was that we should show better examples of how our newer configurable components can be used.

We're aiming to deprecate the older, hardcoded promos:
- `ArticleDonationBanner`
- `DonationBanner`
- `DonationDialog`
- `ThinDonationBanner`

In favour of using newer, configurable components:
- `ThinBanner`
- `ThickBanner`
- `MessageTile`

This PR will tidy up the examples of MessageTile, and **enhance it to fully-replicate** the `EndOfArticle` component (which used `ArticleDonationBanner` under the hood, but now can be done with `MessageTile`). 

The enhancements add two props to `MessageTileButton` to enable it to meet all the requirements we currently have for it.

![Screen Shot 2019-09-13 at 12 07 08 pm](https://user-images.githubusercontent.com/127084/64833344-ff2dcd00-d620-11e9-8214-d0657677b0ee.png)

