### PR TITLE
Build StickyPopup components 

### DIFF
--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import withStyles from '@material-ui/core/styles/withStyles'
+
+const styles = theme => ({})
+
+/**
+ * The `<StickyPopup>` component informs users of something while still allowing the
+ * user to interact with the rest of the page.
+ */
+export const StickyPopup = ({}) => {
+  return (
+
+  )
+}
+
+StickyPopup.defaultProps = {
+}
+
+StickyPopup.propTypes = {
+}
+
+export default withStyles(styles)(StickyPopup)

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -27,11 +27,11 @@ const styles = theme => ({
   message: {
     paddingTop: styledBy('prominent', {
       true: theme.spacing(5),
-      false: theme.spacing(1),
+      false: theme.spacing(1)
     }),
     paddingBottom: styledBy('prominent', {
       true: theme.spacing(5),
-      false: theme.spacing(1),
+      false: theme.spacing(1)
     }),
     paddingRight: theme.spacing(2),
     paddingLeft: theme.spacing(2),
@@ -103,7 +103,6 @@ export const StickyPopup = ({
       onClose={onClose}
     >
       <SnackbarContent
-        className={prominent ? classes.prominent : null}
         classes={classes}
         color={color}
         message={children}

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -50,6 +50,32 @@ const styles = theme => ({
 /**
  * The `<StickyPopup>` component informs users of something while still allowing the
  * user to interact with the rest of the page.
+ *
+ * To change the colour of the StickyPopup, wrap it in a ThemeProvider, pick a theme,
+ * and select a `color` ala: ['default' | 'inherit' | 'primary' | 'secondary']
+ *
+ * ~~~js
+<ThemeProvider theme={defaultTheme()}>
+  <StickyPopup
+    anchorOrigin={{
+      vertical: 'bottom',
+      horizontal: 'right',
+    }}
+    open={this.state.open}
+    color="primary"
+    onClose={this.handleClose}
+    dismissable={true}
+  >
+    <Typography variant="subtitle1">
+      Join over 100,000 Australians who value free evidence-based news.
+    </Typography>
+
+    <Button variant="contained" onClick={action("click")}>
+      Sign up today
+    </Button>
+  </StickyPopup>
+</ThemeProvider />
+ * ~~~
  */
 export const StickyPopup = ({
   anchorOrigin,

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -33,6 +33,7 @@ const styles = theme => ({
       true: theme.spacing(5),
       false: theme.spacing(1)
     }),
+    margin: '0 auto',
     paddingRight: theme.spacing(2),
     paddingLeft: theme.spacing(2),
     textAlign: 'center',

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -41,6 +41,11 @@ const styles = theme => ({
     }
   },
 
+  prominent: {
+    paddingTop: theme.spacing(5),
+    paddingBottom: theme.spacing(5)
+  },
+
   action: {
     padding: 0,
     margin: 0
@@ -85,6 +90,7 @@ export const StickyPopup = ({
   color,
   dismissable,
   open,
+  prominent,
   onClose
 }) => {
   const action = dismissable ? <StickyPopupDismiss onClose={onClose} /> : null
@@ -96,6 +102,7 @@ export const StickyPopup = ({
       onClose={onClose}
     >
       <SnackbarContent
+        className={prominent ? classes.prominent : null}
         classes={classes}
         color={color}
         message={children}
@@ -111,7 +118,8 @@ StickyPopup.defaultProps = {
   children: {},
   color: 'default',
   dismissable: false,
-  open: true
+  open: true,
+  prominent: false
 }
 
 StickyPopup.propTypes = {
@@ -152,7 +160,12 @@ StickyPopup.propTypes = {
   /**
    * If true, the StickyPopup is shown.
    */
-  open: PropTypes.bool.isRequired
+  open: PropTypes.bool.isRequired,
+
+  /**
+   * Optionally boolean to give the message have more padding
+   */
+  prominent: PropTypes.bool
 }
 
 export default withStyles(styles)(StickyPopup)

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -4,7 +4,36 @@ import Snackbar from '@material-ui/core/Snackbar'
 import SnackbarContent from '@material-ui/core/SnackbarContent'
 import withStyles from '@material-ui/core/styles/withStyles'
 
-const styles = theme => ({})
+// Like https://github.com/brunobertolini/styled-by
+const styledBy = (property, mapping) => props => mapping[props[property]]
+
+const styles = theme => ({
+  root: {
+    position: 'relative',
+    backgroundColor: styledBy('color', {
+      default: theme.palette.primary.main,
+      primary: theme.palette.primary.main,
+      secondary: theme.palette.secondary.main
+    }),
+    color: styledBy('color', {
+      default: theme.palette.primary.contrastText,
+      primary: theme.palette.primary.contrastText,
+      secondary: theme.palette.secondary.contrastText
+    })
+  },
+
+  message: {
+    paddingTop: theme.spacing(1),
+    paddingRight: theme.spacing(2),
+    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(2),
+    textAlign: 'center',
+    maxWidth: 360,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+})
 
 /**
  * The `<StickyPopup>` component informs users of something while still allowing the
@@ -14,6 +43,8 @@ export const StickyPopup = ({
   anchorOrigin,
   autoHideDuration,
   children,
+  classes,
+  color,
   open,
   onClose
 }) => {
@@ -25,6 +56,8 @@ export const StickyPopup = ({
       onClose={onClose}
     >
       <SnackbarContent
+        classes={classes}
+        color={color}
         message={children}
       />
     </Snackbar>
@@ -35,6 +68,7 @@ StickyPopup.defaultProps = {
   anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
   autoHideDuration: null,
   children: {},
+  color: 'default',
   open: true
 }
 
@@ -57,6 +91,11 @@ StickyPopup.propTypes = {
   * The content of the StickyPopup.
   */
   children: PropTypes.node.isRequired,
+
+  /**
+   * Optional colour to override the default colour.
+   */
+  color: PropTypes.oneOf(['default', 'primary', 'secondary', 'inherit']),
 
   /**
    * The callback called when button is clicked.

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -4,6 +4,8 @@ import Snackbar from '@material-ui/core/Snackbar'
 import SnackbarContent from '@material-ui/core/SnackbarContent'
 import withStyles from '@material-ui/core/styles/withStyles'
 
+import StickyPopupDismiss from './StickyPopupDismiss'
+
 // Like https://github.com/brunobertolini/styled-by
 const styledBy = (property, mapping) => props => mapping[props[property]]
 
@@ -38,6 +40,11 @@ const styles = theme => ({
       marginBottom: theme.spacing(2)
     }
   },
+
+  action: {
+    padding: 0,
+    margin: 0
+  }
 })
 
 /**
@@ -50,9 +57,11 @@ export const StickyPopup = ({
   children,
   classes,
   color,
+  dismissable,
   open,
   onClose
 }) => {
+  const action = dismissable ? <StickyPopupDismiss onClose={onClose} /> : null
   return (
     <Snackbar
       anchorOrigin={anchorOrigin}
@@ -64,6 +73,7 @@ export const StickyPopup = ({
         classes={classes}
         color={color}
         message={children}
+        action={action}
       />
     </Snackbar>
   )
@@ -74,6 +84,7 @@ StickyPopup.defaultProps = {
   autoHideDuration: null,
   children: {},
   color: 'default',
+  dismissable: false,
   open: true
 }
 
@@ -101,6 +112,11 @@ StickyPopup.propTypes = {
    * Optional colour to override the default colour.
    */
   color: PropTypes.oneOf(['default', 'primary', 'secondary', 'inherit']),
+
+  /**
+   * Optionally show a dismissable icon top right.
+   */
+  dismissable: PropTypes.bool,
 
   /**
    * The callback called when button is clicked.

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -25,9 +25,15 @@ const styles = theme => ({
   },
 
   message: {
-    paddingTop: theme.spacing(1),
+    paddingTop: styledBy('prominent', {
+      true: theme.spacing(5),
+      false: theme.spacing(1),
+    }),
+    paddingBottom: styledBy('prominent', {
+      true: theme.spacing(5),
+      false: theme.spacing(1),
+    }),
     paddingRight: theme.spacing(2),
-    paddingBottom: theme.spacing(1),
     paddingLeft: theme.spacing(2),
     textAlign: 'center',
     maxWidth: 360,
@@ -39,11 +45,6 @@ const styles = theme => ({
     '& > *:not(:last-child)': {
       marginBottom: theme.spacing(2)
     }
-  },
-
-  prominent: {
-    paddingTop: theme.spacing(5),
-    paddingBottom: theme.spacing(5)
   },
 
   action: {

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -117,7 +117,7 @@ StickyPopup.defaultProps = {
   anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
   autoHideDuration: null,
   children: {},
-  color: 'default',
+  color: 'inherit',
   dismissable: false,
   open: true,
   prominent: false
@@ -146,7 +146,7 @@ StickyPopup.propTypes = {
   /**
    * Optional colour to override the default colour.
    */
-  color: PropTypes.oneOf(['default', 'primary', 'secondary', 'inherit']),
+  color: PropTypes.oneOf(['primary', 'secondary', 'inherit']),
 
   /**
    * Optionally show a dismissable icon top right.

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -32,6 +32,11 @@ const styles = theme => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+
+    // To give the children (except the last one) spacing between items.
+    '& > *:not(:last-child)': {
+      marginBottom: theme.spacing(2)
+    }
   },
 })
 

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Snackbar from '@material-ui/core/Snackbar'
+import SnackbarContent from '@material-ui/core/SnackbarContent'
 import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({})
@@ -22,8 +23,11 @@ export const StickyPopup = ({
       autoHideDuration={autoHideDuration}
       open={open}
       onClose={onClose}
-      message={children}
-    />
+    >
+      <SnackbarContent
+        message={children}
+      />
+    </Snackbar>
   )
 }
 

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -156,7 +156,7 @@ StickyPopup.propTypes = {
   /**
    * The callback called when button is clicked.
    */
-  onClose: PropTypes.func.required,
+  onClose: PropTypes.func,
 
   /**
    * If true, the StickyPopup is shown.

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Snackbar from '@material-ui/core/Snackbar'
 import withStyles from '@material-ui/core/styles/withStyles'
 
 const styles = theme => ({})
@@ -8,16 +9,60 @@ const styles = theme => ({})
  * The `<StickyPopup>` component informs users of something while still allowing the
  * user to interact with the rest of the page.
  */
-export const StickyPopup = ({}) => {
+export const StickyPopup = ({
+  anchorOrigin,
+  autoHideDuration,
+  children,
+  open,
+  onClose
+}) => {
   return (
-
+    <Snackbar
+      anchorOrigin={anchorOrigin}
+      autoHideDuration={autoHideDuration}
+      open={open}
+      onClose={onClose}
+      message={children}
+    />
   )
 }
 
 StickyPopup.defaultProps = {
+  anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
+  autoHideDuration: null,
+  children: {},
+  open: true
 }
 
 StickyPopup.propTypes = {
+  /**
+   * Optional number of milliseconds until the StickyPopup should disappear.
+   * `null` to disable.
+   */
+  autoHideDuration: PropTypes.oneOf([PropTypes.number, PropTypes.null]),
+
+  /**
+  * The placement of the StickyPopup
+  */
+  anchorOrigin: PropTypes.shape({
+    vertical: PropTypes.oneOf(['left', 'center', 'right']),
+    horizontal: PropTypes.oneOf(['top', 'bottom'])
+  }),
+
+  /**
+  * The content of the StickyPopup.
+  */
+  children: PropTypes.node.isRequired,
+
+  /**
+   * The callback called when button is clicked.
+   */
+  onClose: PropTypes.func.required,
+
+  /**
+   * If true, the StickyPopup is shown.
+   */
+  open: PropTypes.bool.isRequired
 }
 
 export default withStyles(styles)(StickyPopup)

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -3,11 +3,8 @@ import PropTypes from 'prop-types'
 import Snackbar from '@material-ui/core/Snackbar'
 import SnackbarContent from '@material-ui/core/SnackbarContent'
 import withStyles from '@material-ui/core/styles/withStyles'
-
+import { styledBy } from '../util'
 import StickyPopupDismiss from './StickyPopupDismiss'
-
-// Like https://github.com/brunobertolini/styled-by
-const styledBy = (property, mapping) => props => mapping[props[property]]
 
 const styles = theme => ({
   root: {

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -134,8 +134,8 @@ StickyPopup.propTypes = {
   * The placement of the StickyPopup
   */
   anchorOrigin: PropTypes.shape({
-    vertical: PropTypes.oneOf(['left', 'center', 'right']),
-    horizontal: PropTypes.oneOf(['top', 'bottom'])
+    vertical: PropTypes.oneOf(['top', 'bottom']),
+    horizontal: PropTypes.oneOf(['left', 'center', 'right'])
   }),
 
   /**

--- a/src/StickyPopup/StickyPopup.test.jsx
+++ b/src/StickyPopup/StickyPopup.test.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import SnackbarContent from '@material-ui/core/SnackbarContent'
+
+import StickyPopup from './StickyPopup'
+import StickyPopupDismiss from './StickyPopupDismiss'
+
+describe('<StickyPopup />', () => {
+  describe('dismissable', () => {
+    it('shows a dismiss button if prop is provided', () => {
+      const onClose = jest.fn()
+      const wrapper = mount(
+        <StickyPopup onClose={onClose} dismissable>A message</StickyPopup>
+      )
+      expect(wrapper.find(StickyPopupDismiss).length).toBe(1)
+      expect(wrapper.props().dismissable).toBe(true)
+    })
+
+    it('does not show a dismiss button if prop is not provided', () => {
+      const onClose = jest.fn()
+      const wrapper = mount(
+        <StickyPopup onClose={onClose} dismissable={false}>A message</StickyPopup>
+      )
+      expect(wrapper.find(StickyPopupDismiss).length).toBe(0)
+      expect(wrapper.props().dismissable).toBe(false)
+    })
+
+    describe('onClick callback', () => {
+      it('is called when button is clicked', () => {
+        const onClose = jest.fn()
+        const wrapper = mount(
+          <StickyPopup dismissable onClose={onClose}>A message</StickyPopup>
+        )
+        wrapper.find(StickyPopupDismiss).simulate('click')
+        expect(onClose).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('prominent', () => {
+    it('adds extra padding if prop is provided', () => {
+      const onClose = jest.fn()
+      const wrapper = mount(
+        <StickyPopup prominent onClose={onClose}>A message</StickyPopup>
+      )
+      const SnackbarComponent = wrapper.find(SnackbarContent).getDOMNode().firstElementChild
+      const SnackbarStyles = window.getComputedStyle(SnackbarComponent)
+      expect(SnackbarStyles.getPropertyValue('padding-top')).toBe('40px')
+      expect(SnackbarStyles.getPropertyValue('padding-bottom')).toBe('40px')
+    })
+
+    it('does not add extra padding if prop is provided', () => {
+      const onClose = jest.fn()
+      const wrapper = mount(
+        <StickyPopup prominent={false} onClose={onClose}>A message</StickyPopup>
+      )
+
+      const SnackbarComponent = wrapper.find(SnackbarContent).getDOMNode().firstElementChild
+      const SnackbarStyles = window.getComputedStyle(SnackbarComponent)
+      expect(SnackbarStyles.getPropertyValue('padding-top')).toBe('8px')
+      expect(SnackbarStyles.getPropertyValue('padding-bottom')).toBe('8px')
+    })
+  })
+})

--- a/src/StickyPopup/StickyPopupDismiss.jsx
+++ b/src/StickyPopup/StickyPopupDismiss.jsx
@@ -47,7 +47,7 @@ StickyPopupDismiss.propTypes = {
   /**
    * The callback called when button is clicked.
    */
-  onClose: PropTypes.func.required
+  onClose: PropTypes.func
 }
 
 export default withStyles(styles)(StickyPopupDismiss)

--- a/src/StickyPopup/StickyPopupDismiss.jsx
+++ b/src/StickyPopup/StickyPopupDismiss.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import IconButton from '@material-ui/core/IconButton'
+import CloseIcon from '@material-ui/icons/Close'
+import PropTypes from 'prop-types'
+import withStyles from '@material-ui/core/styles/withStyles'
+
+const styles = theme => ({
+  StickyPopupDismiss: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: theme.spacing(1)
+  }
+})
+
+/**
+ * The `<StickyPopupDismiss />` component is used by `<StickyPopup />`
+ * when it's meant to be dismissable.
+ */
+export const StickyPopupDismiss = ({
+  classes,
+  closeText,
+  onClose
+}) => {
+  return (
+    <IconButton
+      className={classes.StickyPopupDismiss}
+      key='close'
+      aria-label={closeText}
+      color='inherit'
+      onClick={onClose}
+      size='small'
+    >
+      <CloseIcon fontSize='small' />
+    </IconButton>
+  )
+}
+
+StickyPopupDismiss.defaultProps = {
+  closeText: 'Close'
+}
+
+StickyPopupDismiss.propTypes = {
+  /**
+   * An optional string to describe the ARIA label
+   */
+  closeText: PropTypes.string,
+  /**
+   * The callback called when button is clicked.
+   */
+  onClose: PropTypes.func.required
+}
+
+export default withStyles(styles)(StickyPopupDismiss)

--- a/src/StickyPopup/index.js
+++ b/src/StickyPopup/index.js
@@ -1,0 +1,1 @@
+export { default } from './StickyPopup'

--- a/src/StickyPopup/stories/Examples.jsx
+++ b/src/StickyPopup/stories/Examples.jsx
@@ -33,7 +33,7 @@ class RepublishingStickyPopup extends React.Component {
           colour='primary'
           onClick={this.handleOpen}
           style={{ clear: 'both', margin: '16px 0' }}
-        >Toggle Republishing-related StickyPopup message</Button>
+        >Show Republishing StickyPopup</Button>
 
         <StickyPopup
           anchorOrigin={{
@@ -85,7 +85,7 @@ class DonationStickyPopup extends React.Component {
           colour='primary'
           onClick={this.handleOpen}
           style={{ clear: 'both', margin: '16px 0' }}
-        >Toggle Donation-related StickyPopup message</Button>
+        >Show Donation StickyPopup</Button>
 
         <StickyPopup
           anchorOrigin={{
@@ -132,7 +132,7 @@ class NewsletterStickyPopup extends React.Component {
           colour='primary'
           onClick={this.handleOpen}
           style={{ clear: 'both', margin: '16px 0' }}
-        >Toggle Newsletter-related StickyPopup message</Button>
+        >Show Newsletter StickyPopup</Button>
 
         <StickyPopup
           anchorOrigin={{

--- a/src/StickyPopup/stories/Examples.jsx
+++ b/src/StickyPopup/stories/Examples.jsx
@@ -40,10 +40,11 @@ class RepublishingStickyPopup extends React.Component {
             vertical: 'bottom',
             horizontal: 'center'
           }}
-          open={this.state.open}
           color='primary'
-          onClose={this.handleClose}
           dismissable
+          onClose={this.handleClose}
+          open={this.state.open}
+          prominent
         >
           <Typography variant='h5'>
             We believe in the free flow of information
@@ -91,10 +92,10 @@ class DonationStickyPopup extends React.Component {
             vertical: 'bottom',
             horizontal: 'left'
           }}
-          open={this.state.open}
           color='primary'
-          onClose={this.handleClose}
           dismissable
+          onClose={this.handleClose}
+          open={this.state.open}
         >
           <Typography variant='subtitle2'>
             The Conversation provides clean information in a world infected with spin.
@@ -138,10 +139,11 @@ class NewsletterStickyPopup extends React.Component {
             vertical: 'bottom',
             horizontal: 'right'
           }}
-          open={this.state.open}
           color='primary'
-          onClose={this.handleClose}
           dismissable
+          onClose={this.handleClose}
+          open={this.state.open}
+          prominent
         >
           <Typography variant='h5'>
             Join over 100,000 Australians who value free evidence-based news.

--- a/src/StickyPopup/stories/Examples.jsx
+++ b/src/StickyPopup/stories/Examples.jsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import { ThemeProvider } from '../../styles'
+import { action } from '@storybook/addon-actions'
+import { GridLayout } from '../../util'
+
+import Button from '../../Button'
+import Typography from '../../Typography'
+import StickyPopup from '../StickyPopup'
+
+import accentTheme from '../../styles/themes/accent'
+import coreTheme from '../../styles/themes/core'
+import defaultTheme from '../../styles/themes/default'
+
+class RepublishingStickyPopup extends React.Component {
+  state = {
+    open: false
+  }
+
+  handleOpen = event => {
+    action('open')(event)
+    this.setState({ open: !this.state.open })
+  }
+
+  handleClose = event => {
+    action('close')(event)
+    this.setState({ open: false })
+  }
+
+  render () {
+    return (
+      <ThemeProvider theme={defaultTheme()}>
+        <Button
+          colour='primary'
+          onClick={this.handleOpen}
+          style={{ clear: 'both', margin: '16px 0' }}
+        >Toggle Republishing-related StickyPopup message</Button>
+
+        <StickyPopup
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center'
+          }}
+          open={this.state.open}
+          color='primary'
+          onClose={this.handleClose}
+          dismissable
+        >
+          <Typography variant='h5'>
+            We believe in the free flow of information
+          </Typography>
+
+          <Typography variant='subtitle1'>
+            Republish our articles for free, online or in print, under Creative Commons licence.
+          </Typography>
+
+          <Button variant='contained' color='secondary' onClick={action('click')}>
+            Republsh this article
+          </Button>
+        </StickyPopup>
+      </ThemeProvider>
+    )
+  }
+}
+
+class DonationStickyPopup extends React.Component {
+  state = {
+    open: false
+  }
+
+  handleOpen = event => {
+    action('open')(event)
+    this.setState({ open: !this.state.open })
+  }
+
+  handleClose = event => {
+    action('close')(event)
+    this.setState({ open: false })
+  }
+
+  render () {
+    return (
+      <ThemeProvider theme={coreTheme()}>
+        <Button
+          colour='primary'
+          onClick={this.handleOpen}
+          style={{ clear: 'both', margin: '16px 0' }}
+        >Toggle Donation-related StickyPopup message</Button>
+
+        <StickyPopup
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left'
+          }}
+          open={this.state.open}
+          color='primary'
+          onClose={this.handleClose}
+          dismissable
+        >
+          <Typography variant='subtitle2'>
+            The Conversation provides clean information in a world infected with spin.
+          </Typography>
+
+          <Button variant='contained' onClick={action('click')}>
+            Donate now
+          </Button>
+        </StickyPopup>
+      </ThemeProvider>
+    )
+  }
+}
+
+class NewsletterStickyPopup extends React.Component {
+  state = {
+    open: false
+  }
+
+  handleOpen = event => {
+    action('open')(event)
+    this.setState({ open: !this.state.open })
+  }
+
+  handleClose = event => {
+    action('close')(event)
+    this.setState({ open: false })
+  }
+
+  render () {
+    return (
+      <ThemeProvider theme={accentTheme()}>
+        <Button
+          colour='primary'
+          onClick={this.handleOpen}
+          style={{ clear: 'both', margin: '16px 0' }}
+        >Toggle Newsletter-related StickyPopup message</Button>
+
+        <StickyPopup
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right'
+          }}
+          open={this.state.open}
+          color='primary'
+          onClose={this.handleClose}
+          dismissable
+        >
+          <Typography variant='h5'>
+            Join over 100,000 Australians who value free evidence-based news.
+          </Typography>
+
+          <Button variant='contained' color='secondary' onClick={action('click')}>
+            Sign up today
+          </Button>
+        </StickyPopup>
+      </ThemeProvider>
+    )
+  }
+}
+
+export default () => (
+  <GridLayout>
+    <DonationStickyPopup />
+    <RepublishingStickyPopup />
+    <NewsletterStickyPopup />
+  </GridLayout>
+)

--- a/src/StickyPopup/stories/StickyPopup.jsx
+++ b/src/StickyPopup/stories/StickyPopup.jsx
@@ -38,10 +38,11 @@ class ExampleStickyPopup extends React.Component {
             vertical: 'bottom',
             horizontal: 'right'
           }}
-          open={this.state.open}
           color='primary'
-          onClose={this.handleClose}
           dismissable
+          onClose={this.handleClose}
+          open={this.state.open}
+          prominent
         >
           <Typography variant='h5'>
             Join over 100,000 Australians who value free evidence-based news.

--- a/src/StickyPopup/stories/StickyPopup.jsx
+++ b/src/StickyPopup/stories/StickyPopup.jsx
@@ -41,6 +41,7 @@ class ExampleStickyPopup extends React.Component {
           open={this.state.open}
           color='primary'
           onClose={this.handleClose}
+          dismissable
         >
           <Typography variant='h5'>
             Join over 100,000 Australians who value free evidence-based news.

--- a/src/StickyPopup/stories/StickyPopup.jsx
+++ b/src/StickyPopup/stories/StickyPopup.jsx
@@ -39,6 +39,7 @@ class ExampleStickyPopup extends React.Component {
             horizontal: 'right'
           }}
           open={this.state.open}
+          color='primary'
           onClose={this.handleClose}
         >
           <Typography variant='h5'>

--- a/src/StickyPopup/stories/StickyPopup.jsx
+++ b/src/StickyPopup/stories/StickyPopup.jsx
@@ -1,0 +1,61 @@
+import ComponentOverview from '../../ComponentOverview'
+import React from 'react'
+import { ThemeProvider } from '../../styles'
+import { action } from '@storybook/addon-actions'
+
+import Button from '../../Button'
+import StickyPopup, { StickyPopup as UnwrappedStickyPopup } from '../StickyPopup'
+import Typography from '../../Typography'
+
+import accentTheme from '../../styles/themes/accent'
+
+class ExampleStickyPopup extends React.Component {
+  state = {
+    open: true
+  }
+
+  handleOpen = event => {
+    action('open')(event)
+    this.setState({ open: !this.state.open })
+  }
+
+  handleClose = event => {
+    action('close')(event)
+    this.setState({ open: false })
+  }
+
+  render () {
+    return (
+      <ThemeProvider theme={accentTheme()}>
+        <Button
+          colour='primary'
+          onClick={this.handleOpen}
+          style={{ clear: 'both', margin: '16px 0' }}
+        >Toggle StickyPopup message</Button>
+
+        <StickyPopup
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right'
+          }}
+          open={this.state.open}
+          onClose={this.handleClose}
+        >
+          <Typography variant='h5'>
+            Join over 100,000 Australians who value free evidence-based news.
+          </Typography>
+
+          <Button variant='contained' onClick={action('click')}>
+            Sign up today
+          </Button>
+        </StickyPopup>
+      </ThemeProvider>
+    )
+  }
+}
+
+export default () => (
+  <ComponentOverview heading='StickyPopup' component={UnwrappedStickyPopup}>
+    <ExampleStickyPopup />
+  </ComponentOverview>
+)

--- a/src/StickyPopup/stories/index.jsx
+++ b/src/StickyPopup/stories/index.jsx
@@ -1,0 +1,6 @@
+import { storiesOf } from '@storybook/react'
+
+import StickyPopup from './StickyPopup'
+
+storiesOf('StickyPopup', module)
+  .add('Overview', StickyPopup)

--- a/src/StickyPopup/stories/index.jsx
+++ b/src/StickyPopup/stories/index.jsx
@@ -1,6 +1,8 @@
 import { storiesOf } from '@storybook/react'
 
 import StickyPopup from './StickyPopup'
+import Examples from './Examples'
 
 storiesOf('StickyPopup', module)
   .add('Overview', StickyPopup)
+  .add('Examples', Examples)

--- a/src/ThickBanner/ThickBanner.jsx
+++ b/src/ThickBanner/ThickBanner.jsx
@@ -3,12 +3,10 @@ import CloseIcon from '@material-ui/icons/Close'
 import MaterialIconButton from '@material-ui/core/IconButton'
 import PropTypes from 'prop-types'
 import Typography from '../Typography'
+import { styledBy } from '../util'
 import React from 'react'
 import Paper from '@material-ui/core/Paper'
 import withStyles from '@material-ui/core/styles/withStyles'
-
-// Like https://github.com/brunobertolini/styled-by
-const styledBy = (property, mapping) => props => mapping[props[property]]
 
 const styles = theme => ({
   box: {

--- a/src/util.jsx
+++ b/src/util.jsx
@@ -20,6 +20,9 @@ export const GridLayout = ({ children, ...other }) => {
   )
 }
 
+// Like https://github.com/brunobertolini/styled-by
+export const styledBy = (property, mapping) => props => mapping[props[property]]
+
 /**
  * Returns an array of prop definitions, based on the docgen info for the given
  * component.


### PR DESCRIPTION
REFS https://trello.com/c/zQvueItJ/1000-sticky-popup
REFS https://trello.com/c/yjOzW8cl/1008-build-sticky-popup-component-in-tcui

## Task: Adapt MUI's 'Snackbar' component to our colour themes and font styles to become "Sticky pop up"**

- MUI: https://material-ui.com/components/snackbars/ + https://material.io/components/snackbars/
- Our design: https://gallery.io/projects/MCHbtQVoQ2HCZWiQBR82z4LY/files/MCEJu8Y2hyDScXXP1OFK2xzMOO7rIvg1d1Y

## Background:
This update is one of many design recommendations for enhancing our email experience. The intention is that a snackbar would appear after 60-80% scroll on an article page. It could promote newsletter subscription today (purple), be reused for donations later in the year (red) and potentially be a consideration for republishing promos (default blue grey). Like all components, the snackbar should be device agnostic. 

## This PR

This PR creates a `StickyPopup` component. Under the hood, it builds a MUI `Snackbar` component, and automatically wraps the content in a `SnackbarContent` component; this allows us to wrap the whole thing in a `ThemeProvider` and get the styling we want.

It also adds a little space between all the `children` props; you pass the message sub-components (like `Typography` or `Button` components) in as children.

There are a few boolean props; `prominent` makes the spacing a bit larger, and `dismissable` includes a `StickyPopupDismiss` icon top-right of the `StickyPopup`.

## Example Usage:

```js
<ThemeProvider theme={defaultTheme()}>
  <StickyPopup
    anchorOrigin={{
      vertical: 'bottom',
      horizontal: 'right',
    }}
    open={this.state.open}
    color="primary"
    onClose={this.handleClose}
    dismissable={true}
  >
    <Typography variant="subtitle1">
      Join over 100,000 Australians who value free evidence-based news.
    </Typography>
    <Button variant="contained" onClick={action("click")}>
      Sign up today
    </Button>
  </StickyPopup>
</ThemeProvider />
```

## Differences between TC & MUI

- Unlike MUI's snackbar, this should support dismissable behaviour when required

## Screenshots
![popups](https://user-images.githubusercontent.com/127084/65219249-8be1fa80-dafb-11e9-929c-5daa98745d39.gif)

## To Do in upcoming PRs
- [ ] Update TCUI font sizes for Typography components. This will allow us to more closely match designs by @ZoeJazz 
- [ ] Optionally disable ClickAwayHandlers (you can click anywhere outside the `StickyPopup` and it'll dismiss it. Maybe we want make that optional?
- [ ] Add functionality to control slide direction, which we will definitely use to slide in from the bottom on mobiles &mdash; https://material-ui.com/components/snackbars/#control-slide-direction
- [ ] Add functionality to control transition type &mdash; https://material-ui.com/components/snackbars/#change-transition