### PR TITLE
Update font sizes and add support for responsive typography variants to component library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Updates font sizes for Typography
+* Updates documentation and components to use new font sizes
+
 # 2.13.0 (2019-09-17)
 
 * Move ThinBanner and ThickBanner to top level, outside promos.

--- a/src/ArticleDonationBanner/stories/ArticleDonationBanner.jsx
+++ b/src/ArticleDonationBanner/stories/ArticleDonationBanner.jsx
@@ -13,7 +13,7 @@ export default () => (
     </div>
 
     <ArticleDonationBanner onClick={action('clicked')} donateText='Donate now'>
-      <Typography variant='h6' gutterBottom>Before you go...</Typography>
+      <Typography variant='h3' gutterBottom>Before you go...</Typography>
       <Typography variant='body1' paragraph>
         The Conversation serves society by making knowledge accessible to everyone, not just a select few. Our only agenda is a better informed public. If you care about what we do please make a donation now and help secure our future.
       </Typography>

--- a/src/DonationBanner/DonationBanner.jsx
+++ b/src/DonationBanner/DonationBanner.jsx
@@ -70,7 +70,7 @@ export const DonationBanner = ({
       <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
         <CloseIcon />
       </MaterialIconButton>
-      <Typography variant='h5' paragraph className={classes.typography}>{children}</Typography>
+      <Typography variant='h4' paragraph className={classes.typography}>{children}</Typography>
       <Button prominent className={classes.button} onClick={onClick}>
         {donateText}
       </Button>

--- a/src/DonationDialog/stories/DonationDialog.jsx
+++ b/src/DonationDialog/stories/DonationDialog.jsx
@@ -50,7 +50,7 @@ function ExampleDialog () {
           <DialogAvatar src={koala} />
           <DialogInlineTitle>Support close combat training for koalas</DialogInlineTitle>
           <DialogContent>
-            <Typography variant='body2'>{CONTENT}</Typography>
+            <Typography variant='subtitle1'>{CONTENT}</Typography>
             <MiniDivider />
             <Person name='Colonel Koala' caption='Leader of the Koala Freedom Collective' />
           </DialogContent>

--- a/src/MessageTile/MessageTileBody.jsx
+++ b/src/MessageTile/MessageTileBody.jsx
@@ -11,7 +11,7 @@ const styles = theme => ({
 
 export const MessageTileBody = ({ children, classes }) => {
   return (
-    <Typography className={classes.body} variant='body2'>
+    <Typography className={classes.body} variant='subtitle1'>
       {children}
     </Typography>
   )

--- a/src/MessageTile/MessageTileHeader.jsx
+++ b/src/MessageTile/MessageTileHeader.jsx
@@ -11,7 +11,7 @@ const styles = theme => ({
 
 export const MessageTileHeader = ({ children, classes }) => {
   return (
-    <Typography className={classes.title} variant='h6'>
+    <Typography className={classes.title} variant='h3'>
       { children }
     </Typography>
   )

--- a/src/ThickBanner/ThickBanner.jsx
+++ b/src/ThickBanner/ThickBanner.jsx
@@ -94,7 +94,7 @@ export const ThickBanner = ({ children,
       <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
         <CloseIcon />
       </MaterialIconButton>
-      <Typography variant='h5' paragraph className={classes.typography}>{children}</Typography>
+      <Typography variant='h3' paragraph className={classes.typography}>{children}</Typography>
       <Button prominent className={classes.button} onClick={onClick}>
         {buttonText}
       </Button>

--- a/src/Typography/Typography.jsx
+++ b/src/Typography/Typography.jsx
@@ -1,6 +1,7 @@
 import MaterialTypography from '@material-ui/core/Typography'
 import PropTypes from 'prop-types'
 import React from 'react'
+import withStyles from '@material-ui/core/styles/withStyles'
 
 /**
  * The `<Typography>` component contains a block of text which is styled
@@ -14,6 +15,100 @@ import React from 'react'
  * </Typography>
  * ~~~
  */
+const styles = theme => ({
+  h1: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: '1.75rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '2.75rem'
+    }
+  },
+
+  h2: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: '1.625rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '2rem'
+    }
+  },
+
+  h3: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: '1.375rem'
+  },
+
+  h4: {
+    fontFamily: 'Montserrat',
+    fontWeight: 600,
+    fontSize: '1.25rem'
+  },
+
+  h5: {
+    fontFamily: 'Montserrat',
+    fontWeight: 600,
+    fontSize: '1.125rem'
+  },
+
+  h6: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    lineHeight: 'normal',
+    letterSpacing: '0.25px',
+    fontSize: '1rem'
+  },
+
+  body1: {
+    fontFamily: 'Libre Baskerville',
+    lineHeight: '1.5',
+    fontSize: '1rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1.125rem'
+    }
+  },
+
+  body2: {
+    fontFamily: 'Noto Sans',
+    lineHeight: '1.5',
+    fontSize: '1.125rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1.5rem'
+    }
+  },
+
+  button: {
+    letterSpacing: 0.25,
+    textTransform: 'none',
+    fontSize: '0.875rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1rem'
+    }
+  },
+
+  overline: {
+    letterSpacing: 0.25,
+    textTransform: 'none',
+    fontSize: '0.875rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1rem'
+    }
+  },
+
+  caption: {
+    fontSize: '0.75rem'
+  },
+
+  subtitle1: {
+    fontSize: '1rem'
+  },
+
+  subtitle2: {
+    fontSize: '0.75rem'
+  }
+})
+
 export const Typography = ({ children, colour, ...other }) => (
   <MaterialTypography color={colour} {...other}>
     {children}
@@ -87,4 +182,4 @@ Typography.defaultProps = {
   variant: 'inherit'
 }
 
-export default Typography
+export default withStyles(styles)(Typography)

--- a/src/dialog/DialogInlineTitle.jsx
+++ b/src/dialog/DialogInlineTitle.jsx
@@ -17,7 +17,7 @@ const styles = theme => ({
  */
 const DialogInlineTitle = ({ children, ...other }) => (
   <MaterialDialogTitle disableTypography {...other}>
-    <Typography color='inherit' variant='h6'>
+    <Typography color='inherit' variant='h4'>
       {children}
     </Typography>
   </MaterialDialogTitle>

--- a/src/dialog/DialogTitle.jsx
+++ b/src/dialog/DialogTitle.jsx
@@ -16,7 +16,7 @@ const styles = theme => ({
  */
 const DialogTitle = ({ children, ...other }) => (
   <MaterialDialogTitle disableTypography {...other}>
-    <Typography color='inherit' variant='h6'>
+    <Typography color='inherit' variant='h4'>
       {children}
     </Typography>
   </MaterialDialogTitle>

--- a/src/dialog/stories/content.jsx
+++ b/src/dialog/stories/content.jsx
@@ -52,7 +52,7 @@ class ExampleDialog extends React.Component {
         <Dialog open={this.state.open} onClose={this.handleClose}>
           <DialogTitle>Title</DialogTitle>
           <DialogContent>
-            <Typography variant='body2'>{LIPSUM}</Typography>
+            <Typography variant='subtitle1'>{LIPSUM}</Typography>
           </DialogContent>
           <DialogActions>
             <DialogAction onClick={this.handleClose} variant='primary'>OK</DialogAction>

--- a/src/pickers/stories/usage.jsx
+++ b/src/pickers/stories/usage.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
 import { withDocs } from 'storybook-readme'
+import { ThemeProvider } from '../../styles'
+import defaultTheme from '../../styles/themes/default'
 
 import MomentUtils from '@date-io/moment'
 import { DatePicker, DateTimePicker, TimePicker } from '../..'
@@ -28,8 +30,10 @@ const changeDate = (momentDate) => {
 
 export default withDocs(md, () =>
   <GridLayout>
-    <DatePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
-    <TimePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
-    <DateTimePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
+    <ThemeProvider theme={defaultTheme()}>
+      <DatePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
+      <TimePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
+      <DateTimePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
+    </ThemeProvider>
   </GridLayout>
 )

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -1,8 +1,8 @@
 import core from '../palettes/core'
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createMuiTheme } from '@material-ui/core/styles'
 
 // Create a new theme to use it's default breakpoints
-const theme = createMuiTheme();
+const theme = createMuiTheme()
 
 export const typography = {
   fontFamily: 'Noto Sans',
@@ -11,9 +11,9 @@ export const typography = {
   button: {
     letterSpacing: 0.25,
     textTransform: 'none',
-    fontSize: "0.875rem",
+    fontSize: '0.875rem',
     [theme.breakpoints.up('sm')]: {
-      fontSize: "1rem"
+      fontSize: '1rem'
     }
   }
 }

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -3,38 +3,80 @@ import core from '../palettes/core'
 export const typography = {
   fontFamily: 'Noto Sans',
 
-  h1: { fontFamily: 'Montserrat', fontWeight: 700 },
-  h2: { fontFamily: 'Montserrat', fontWeight: 700 },
-  h3: { fontFamily: 'Montserrat', fontWeight: 700 },
-  h4: { fontFamily: 'Montserrat', fontWeight: 600 },
-  h5: { fontFamily: 'Montserrat', fontWeight: 600 },
+  h1: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: 28,
+  },
+
+  h2: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: 26,
+  },
+
+  h3: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: 22,
+  },
+
+  h4: {
+    fontFamily: 'Montserrat',
+    fontWeight: 600,
+    fontSize: 20,
+  },
+
+  h5: {
+    fontFamily: 'Montserrat',
+    fontWeight: 600,
+    fontSize: 18,
+  },
+
   h6: {
     fontFamily: 'Montserrat',
     fontWeight: 700,
     lineHeight: 'normal',
-    letterSpacing: '0.25px'
+    letterSpacing: '0.25px',
+    fontSize: 16,
   },
 
   body1: {
     fontFamily: 'Libre Baskerville',
     fontSize: '1rem',
-    lineHeight: '1.5'
+    lineHeight: '1.5',
+    fontSize: 16
   },
 
   body2: {
     fontFamily: 'Noto Sans',
     fontSize: '0.875rem',
-    lineHeight: '1.5'
+    lineHeight: '1.5',
+    fontSize: 18
   },
 
   button: {
     letterSpacing: 0.25,
-    textTransform: 'none'
+    textTransform: 'none',
+    fontSize: 14
   },
 
   overline: {
     letterSpacing: 0.25,
-    textTransform: 'none'
+    textTransform: 'none',
+    fontSize: 14
+  },
+
+  caption: {
+    fontSize: 12
+  },
+
+  subtitle1: {
+    fontSize: 16
+  },
+
+  subtitle2: {
+    fontSize: 12
   }
 }
 

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -1,4 +1,8 @@
 import core from '../palettes/core'
+import { createMuiTheme } from '@material-ui/core/styles';
+
+// Create a new theme to use it's default breakpoints
+const theme = createMuiTheme();
 
 export const typography = {
   fontFamily: 'Noto Sans',
@@ -7,31 +11,37 @@ export const typography = {
   h1: {
     fontFamily: 'Montserrat',
     fontWeight: 700,
-    fontSize: 28,
+    fontSize: "1.75rem",
+    [theme.breakpoints.up('sm')]: {
+      fontSize: "2.75rem"
+    }
   },
 
   h2: {
     fontFamily: 'Montserrat',
     fontWeight: 700,
-    fontSize: 26,
+    fontSize: "1.625rem",
+    [theme.breakpoints.up('sm')]: {
+      fontSize: "2rem"
+    }
   },
 
   h3: {
     fontFamily: 'Montserrat',
     fontWeight: 700,
-    fontSize: 22,
+    fontSize: "1.375rem",
   },
 
   h4: {
     fontFamily: 'Montserrat',
     fontWeight: 600,
-    fontSize: 20,
+    fontSize: "1.25rem",
   },
 
   h5: {
     fontFamily: 'Montserrat',
     fontWeight: 600,
-    fontSize: 18,
+    fontSize: "1.125rem",
   },
 
   h6: {
@@ -39,45 +49,56 @@ export const typography = {
     fontWeight: 700,
     lineHeight: 'normal',
     letterSpacing: '0.25px',
-    fontSize: 16,
+    fontSize: "1rem",
   },
 
   body1: {
     fontFamily: 'Libre Baskerville',
-    fontSize: '1rem',
     lineHeight: '1.5',
-    fontSize: 16
+    fontSize: "1rem",
+    [theme.breakpoints.up('sm')]: {
+      fontSize: "1.125rem"
+    }
   },
 
   body2: {
     fontFamily: 'Noto Sans',
     fontSize: '0.875rem',
     lineHeight: '1.5',
-    fontSize: 18
+    fontSize: "1.125rem",
+    [theme.breakpoints.up('sm')]: {
+      fontSize: "1.5rem"
+    }
   },
 
   button: {
     letterSpacing: 0.25,
     textTransform: 'none',
-    fontSize: 14
+    fontSize: "0.875rem",
+    [theme.breakpoints.up('sm')]: {
+      fontSize: "1rem"
+    }
   },
 
   overline: {
     letterSpacing: 0.25,
     textTransform: 'none',
-    fontSize: 14
+    fontSize: "0.875rem",
+    [theme.breakpoints.up('sm')]: {
+      fontSize: "1rem"
+    }
   },
 
   caption: {
-    fontSize: 12
+    fontSize: "0.75rem"
   },
 
   subtitle1: {
-    fontSize: 16
+    fontSize: "1rem",
   },
 
   subtitle2: {
-    fontSize: 12
+    fontSize: "0.75rem"
   }
 }
 

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -8,69 +8,6 @@ export const typography = {
   fontFamily: 'Noto Sans',
   fontSize: 16,
 
-  h1: {
-    fontFamily: 'Montserrat',
-    fontWeight: 700,
-    fontSize: "1.75rem",
-    [theme.breakpoints.up('sm')]: {
-      fontSize: "2.75rem"
-    }
-  },
-
-  h2: {
-    fontFamily: 'Montserrat',
-    fontWeight: 700,
-    fontSize: "1.625rem",
-    [theme.breakpoints.up('sm')]: {
-      fontSize: "2rem"
-    }
-  },
-
-  h3: {
-    fontFamily: 'Montserrat',
-    fontWeight: 700,
-    fontSize: "1.375rem",
-  },
-
-  h4: {
-    fontFamily: 'Montserrat',
-    fontWeight: 600,
-    fontSize: "1.25rem",
-  },
-
-  h5: {
-    fontFamily: 'Montserrat',
-    fontWeight: 600,
-    fontSize: "1.125rem",
-  },
-
-  h6: {
-    fontFamily: 'Montserrat',
-    fontWeight: 700,
-    lineHeight: 'normal',
-    letterSpacing: '0.25px',
-    fontSize: "1rem",
-  },
-
-  body1: {
-    fontFamily: 'Libre Baskerville',
-    lineHeight: '1.5',
-    fontSize: "1rem",
-    [theme.breakpoints.up('sm')]: {
-      fontSize: "1.125rem"
-    }
-  },
-
-  body2: {
-    fontFamily: 'Noto Sans',
-    fontSize: '0.875rem',
-    lineHeight: '1.5',
-    fontSize: "1.125rem",
-    [theme.breakpoints.up('sm')]: {
-      fontSize: "1.5rem"
-    }
-  },
-
   button: {
     letterSpacing: 0.25,
     textTransform: 'none',
@@ -78,27 +15,6 @@ export const typography = {
     [theme.breakpoints.up('sm')]: {
       fontSize: "1rem"
     }
-  },
-
-  overline: {
-    letterSpacing: 0.25,
-    textTransform: 'none',
-    fontSize: "0.875rem",
-    [theme.breakpoints.up('sm')]: {
-      fontSize: "1rem"
-    }
-  },
-
-  caption: {
-    fontSize: "0.75rem"
-  },
-
-  subtitle1: {
-    fontSize: "1rem",
-  },
-
-  subtitle2: {
-    fontSize: "0.75rem"
   }
 }
 

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -2,6 +2,7 @@ import core from '../palettes/core'
 
 export const typography = {
   fontFamily: 'Noto Sans',
+  fontSize: 16,
 
   h1: {
     fontFamily: 'Montserrat',


### PR DESCRIPTION
https://trello.com/c/k7EZNukl/935-add-support-for-responsive-typography-variants-to-component-library

Key points:
 - Change base fontSize to 16px
 - Ensure all typography variants are using `rem` units as preferred by MUI

Here are the variants we want (again, these should be translated to `rem` and assume a base of 16px).

"Desktop" is considered to be `breakpoints.up('sm')`, aka 600px to infinity.

```
// h1 - 28px (44px on desktop)
// h2 - 26px (32px on desktop)
// h3 - 22px
// h4 - 20px
// h5 - 18px
// h6 - 16px
// Overline - 14px (16px on desktop)
// Subtitle 1 - 16px
// Subtitle 2 - 12px
// Caption - 12px
// Button - 14px (16px on desktop)
// Body 1 - 16px (18px on desktop)
// Body 2 - 18px (24px on desktop)
```

Here is an example of how we can add responsive font sizes, probably can be organised better, but this is just proof that it works:
https://github.com/conversation/ui/compare/responsive-typography-variants-example

This may also require us to:
- Update spacing and type styles in all Banners
- Update spacing and type styles in Pop up / Dialog
- Update spacing and type styles in all Message Tiles - Talk to Zoe for instructions on how best to implement changes to components

# Typography

## Left is this PR, right is master

### Default / mobile sizes
<img width="1440" alt="Screen Shot 2019-09-23 at 4 13 50 pm" src="https://user-images.githubusercontent.com/127084/65404783-4b48f080-de1d-11e9-8aeb-b07b6e8ead45.png">

### Desktop sizes
<img width="1440" alt="Screen Shot 2019-09-23 at 4 14 25 pm" src="https://user-images.githubusercontent.com/127084/65404788-513ed180-de1d-11e9-8bc7-8fe1c96a065b.png">

**Especially note here that the font sizes are much better for smaller devices**

## Left is this mobile, right is desktop - this is the responsive resizing at work

<img width="1440" alt="Screen Shot 2019-09-23 at 4 16 21 pm" src="https://user-images.githubusercontent.com/127084/65404835-81867000-de1d-11e9-94c7-54438cb24f93.png">


# Comparison of components
Left is this PR, right is master

**Now**, a bunch of components needed tweaks. Most were changing a `h5` to ` h3` or so. Some will require changes on TC's end, as the components they accept (for the most part `Typography` components) will have changed font sizes. Any ones I changed the examples of will need to be updated on TC as well, after this has has been versioned.

### ArticleDonationBanner
<img width="1440" alt="ArticleDonationBanner" src="https://user-images.githubusercontent.com/127084/65403288-43d21900-de16-11e9-9839-682522bdba36.png">

### Autocomplete
<img width="1440" alt="Autocomplete" src="https://user-images.githubusercontent.com/127084/65403289-446aaf80-de16-11e9-930e-825f934e1656.png">

### Button
<img width="1440" alt="Button" src="https://user-images.githubusercontent.com/127084/65403290-446aaf80-de16-11e9-8765-4387c2c64dfd.png">

### Dialog
<img width="1440" alt="Dialog" src="https://user-images.githubusercontent.com/127084/65403291-446aaf80-de16-11e9-9c09-2261baeba128.png">

### DonationBanner
<img width="1440" alt="DonationBanner" src="https://user-images.githubusercontent.com/127084/65403292-45034600-de16-11e9-8a8c-e2686f5db49e.png">

### DonationDialog
<img width="1440" alt="DonationDialog" src="https://user-images.githubusercontent.com/127084/65403293-45034600-de16-11e9-8fc9-6d7ad703e960.png">

### Dropdown
<img width="1440" alt="Dropdown" src="https://user-images.githubusercontent.com/127084/65403294-45034600-de16-11e9-95b1-7bbcfdd49f7f.png">

### MessageTile
<img width="1440" alt="MessageTile" src="https://user-images.githubusercontent.com/127084/65403296-45034600-de16-11e9-9531-063581ad690d.png">
<img width="1440" alt="MessageTile Examples 1" src="https://user-images.githubusercontent.com/127084/65403425-fbffc180-de16-11e9-80cd-aeda379853ef.png">
<img width="1440" alt="MessageTile Examples 2" src="https://user-images.githubusercontent.com/127084/65403426-fbffc180-de16-11e9-8a2d-5538fd362797.png">

### Person
<img width="1440" alt="Person" src="https://user-images.githubusercontent.com/127084/65403297-459bdc80-de16-11e9-93c6-9d91aea14507.png">

### Pickers closed
<img width="1440" alt="Pickers closed" src="https://user-images.githubusercontent.com/127084/65403298-459bdc80-de16-11e9-94a3-3ecfbe96375e.png">

### Pickers Date and Time
<img width="1440" alt="Pickers Date and Time" src="https://user-images.githubusercontent.com/127084/65403299-459bdc80-de16-11e9-936b-f39999828706.png">

### Pickers Date
<img width="1440" alt="Pickers Date" src="https://user-images.githubusercontent.com/127084/65403300-46347300-de16-11e9-968c-d632bc68d1c9.png">

### Pickers Time
<img width="1440" alt="Pickers Time" src="https://user-images.githubusercontent.com/127084/65403301-46347300-de16-11e9-8e8c-1230d2f3ef36.png">

### TextFields
<img width="1440" alt="TextFields" src="https://user-images.githubusercontent.com/127084/65403302-46347300-de16-11e9-9c66-4c0191e5a5b1.png">

### ThickBanner
<img width="1440" alt="ThinBanner" src="https://user-images.githubusercontent.com/127084/65403304-46cd0980-de16-11e9-980a-d06afaec2d96.png">

### ThinBanner
<img width="1440" alt="ThinDonationBanner" src="https://user-images.githubusercontent.com/127084/65403305-46cd0980-de16-11e9-8b15-a415edb4840a.png">

### ThinDonationBanner
<img width="1440" alt="ThickBanner" src="https://user-images.githubusercontent.com/127084/65403303-46cd0980-de16-11e9-8e13-8339d7501345.png">
