### PR TITLE
Updates font sizes for Typography component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Updates font sizes for Typography
+
 # 2.13.0 (2019-09-17)
 
 * Move ThinBanner and ThickBanner to top level, outside promos.

--- a/src/Typography/Typography.jsx
+++ b/src/Typography/Typography.jsx
@@ -1,6 +1,7 @@
 import MaterialTypography from '@material-ui/core/Typography'
 import PropTypes from 'prop-types'
 import React from 'react'
+import withStyles from '@material-ui/core/styles/withStyles'
 
 /**
  * The `<Typography>` component contains a block of text which is styled
@@ -14,6 +15,82 @@ import React from 'react'
  * </Typography>
  * ~~~
  */
+const styles = theme => ({
+  h1: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: '1.75rem'
+  },
+
+  h2: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: '1.625rem'
+  },
+
+  h3: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    fontSize: '1.375rem'
+  },
+
+  h4: {
+    fontFamily: 'Montserrat',
+    fontWeight: 600,
+    fontSize: '1.25rem'
+  },
+
+  h5: {
+    fontFamily: 'Montserrat',
+    fontWeight: 600,
+    fontSize: '1.125rem'
+  },
+
+  h6: {
+    fontFamily: 'Montserrat',
+    fontWeight: 700,
+    lineHeight: 'normal',
+    letterSpacing: '0.25px',
+    fontSize: '1rem'
+  },
+
+  body1: {
+    fontFamily: 'Libre Baskerville',
+    lineHeight: '1.5',
+    fontSize: '1rem'
+  },
+
+  body2: {
+    fontFamily: 'Noto Sans',
+    lineHeight: '1.5',
+    fontSize: '1.125rem'
+  },
+
+  button: {
+    letterSpacing: 0.25,
+    textTransform: 'none',
+    fontSize: '0.875rem'
+  },
+
+  overline: {
+    letterSpacing: 0.25,
+    textTransform: 'none',
+    fontSize: '0.875rem'
+  },
+
+  caption: {
+    fontSize: '0.75rem'
+  },
+
+  subtitle1: {
+    fontSize: '1rem'
+  },
+
+  subtitle2: {
+    fontSize: '0.75rem'
+  }
+})
+
 export const Typography = ({ children, colour, ...other }) => (
   <MaterialTypography color={colour} {...other}>
     {children}
@@ -87,4 +164,4 @@ Typography.defaultProps = {
   variant: 'inherit'
 }
 
-export default Typography
+export default withStyles(styles)(Typography)

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -2,39 +2,12 @@ import core from '../palettes/core'
 
 export const typography = {
   fontFamily: 'Noto Sans',
-
-  h1: { fontFamily: 'Montserrat', fontWeight: 700 },
-  h2: { fontFamily: 'Montserrat', fontWeight: 700 },
-  h3: { fontFamily: 'Montserrat', fontWeight: 700 },
-  h4: { fontFamily: 'Montserrat', fontWeight: 600 },
-  h5: { fontFamily: 'Montserrat', fontWeight: 600 },
-  h6: {
-    fontFamily: 'Montserrat',
-    fontWeight: 700,
-    lineHeight: 'normal',
-    letterSpacing: '0.25px'
-  },
-
-  body1: {
-    fontFamily: 'Libre Baskerville',
-    fontSize: '1rem',
-    lineHeight: '1.5'
-  },
-
-  body2: {
-    fontFamily: 'Noto Sans',
-    fontSize: '0.875rem',
-    lineHeight: '1.5'
-  },
+  fontSize: 16,
 
   button: {
     letterSpacing: 0.25,
-    textTransform: 'none'
-  },
-
-  overline: {
-    letterSpacing: 0.25,
-    textTransform: 'none'
+    textTransform: 'none',
+    fontSize: '0.875rem'
   }
 }
 


### PR DESCRIPTION
https://trello.com/c/k7EZNukl/935-add-support-for-responsive-typography-variants-to-component-library
https://trello.com/c/uEHMo2ee/1061-set-new-tcui-default-font-sizes

This is part 1 of breaking up https://github.com/conversation/ui/pull/102

This alleviates the themes of knowing too much about the typography, and instead imbues the `Typography` component with knowing how to size itself.

Originally, in https://github.com/conversation/ui/pull/102, I'd added the styles to the common theme; this caused third party components to display a bit out of whack.

Now, if we only set the base font to Noto Sans and the size to 16px, it keeps th e third party components looking as expected (with minor visual differences), and any component using our own Typography component will require _minor_ updates as well.

- h1 - 28px
- h2 - 26px
- h3 - 22px
- h4 - 20px
- h5 - 18px
- h6 - 16px
- Overline - 14px
- Subtitle 1 - 16px
- Subtitle 2 - 12px
- Caption - 12px
- Button - 14px
- Body 1 - 16px
- Body 2 - 18px

In follow-up PRs, I'll update the components to keep a similar visual look, and then add the responsive font sizes.

<img width="1440" alt="Screen Shot 2019-09-26 at 9 45 53 am" src="https://user-images.githubusercontent.com/127084/65647566-7b250d80-e042-11e9-8d27-4db88d1c03da.png">


