### PR TITLE
Update TCUI components to use new font sizes

### DIFF
--- a/src/ArticleDonationBanner/stories/ArticleDonationBanner.jsx
+++ b/src/ArticleDonationBanner/stories/ArticleDonationBanner.jsx
@@ -13,7 +13,7 @@ export default () => (
     </div>
 
     <ArticleDonationBanner onClick={action('clicked')} donateText='Donate now'>
-      <Typography variant='h6' gutterBottom>Before you go...</Typography>
+      <Typography variant='h3' gutterBottom>Before you go...</Typography>
       <Typography variant='body1' paragraph>
         The Conversation serves society by making knowledge accessible to everyone, not just a select few. Our only agenda is a better informed public. If you care about what we do please make a donation now and help secure our future.
       </Typography>

--- a/src/DonationBanner/DonationBanner.jsx
+++ b/src/DonationBanner/DonationBanner.jsx
@@ -70,7 +70,7 @@ export const DonationBanner = ({
       <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
         <CloseIcon />
       </MaterialIconButton>
-      <Typography variant='h5' paragraph className={classes.typography}>{children}</Typography>
+      <Typography variant='h4' paragraph className={classes.typography}>{children}</Typography>
       <Button prominent className={classes.button} onClick={onClick}>
         {donateText}
       </Button>

--- a/src/DonationDialog/stories/DonationDialog.jsx
+++ b/src/DonationDialog/stories/DonationDialog.jsx
@@ -50,7 +50,7 @@ function ExampleDialog () {
           <DialogAvatar src={koala} />
           <DialogInlineTitle>Support close combat training for koalas</DialogInlineTitle>
           <DialogContent>
-            <Typography variant='body2'>{CONTENT}</Typography>
+            <Typography variant='subtitle1'>{CONTENT}</Typography>
             <MiniDivider />
             <Person name='Colonel Koala' caption='Leader of the Koala Freedom Collective' />
           </DialogContent>

--- a/src/MessageTile/MessageTileBody.jsx
+++ b/src/MessageTile/MessageTileBody.jsx
@@ -11,7 +11,7 @@ const styles = theme => ({
 
 export const MessageTileBody = ({ children, classes }) => {
   return (
-    <Typography className={classes.body} variant='body2'>
+    <Typography className={classes.body} variant='subtitle1'>
       {children}
     </Typography>
   )

--- a/src/MessageTile/MessageTileHeader.jsx
+++ b/src/MessageTile/MessageTileHeader.jsx
@@ -11,7 +11,7 @@ const styles = theme => ({
 
 export const MessageTileHeader = ({ children, classes }) => {
   return (
-    <Typography className={classes.title} variant='h6'>
+    <Typography className={classes.title} variant='h3'>
       { children }
     </Typography>
   )

--- a/src/ThickBanner/ThickBanner.jsx
+++ b/src/ThickBanner/ThickBanner.jsx
@@ -94,7 +94,7 @@ export const ThickBanner = ({ children,
       <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
         <CloseIcon />
       </MaterialIconButton>
-      <Typography variant='h5' paragraph className={classes.typography}>{children}</Typography>
+      <Typography variant='h3' paragraph className={classes.typography}>{children}</Typography>
       <Button prominent className={classes.button} onClick={onClick}>
         {buttonText}
       </Button>

--- a/src/dialog/DialogInlineTitle.jsx
+++ b/src/dialog/DialogInlineTitle.jsx
@@ -17,7 +17,7 @@ const styles = theme => ({
  */
 const DialogInlineTitle = ({ children, ...other }) => (
   <MaterialDialogTitle disableTypography {...other}>
-    <Typography color='inherit' variant='h6'>
+    <Typography color='inherit' variant='h4'>
       {children}
     </Typography>
   </MaterialDialogTitle>

--- a/src/dialog/DialogTitle.jsx
+++ b/src/dialog/DialogTitle.jsx
@@ -16,7 +16,7 @@ const styles = theme => ({
  */
 const DialogTitle = ({ children, ...other }) => (
   <MaterialDialogTitle disableTypography {...other}>
-    <Typography color='inherit' variant='h6'>
+    <Typography color='inherit' variant='h4'>
       {children}
     </Typography>
   </MaterialDialogTitle>

--- a/src/dialog/stories/content.jsx
+++ b/src/dialog/stories/content.jsx
@@ -52,7 +52,7 @@ class ExampleDialog extends React.Component {
         <Dialog open={this.state.open} onClose={this.handleClose}>
           <DialogTitle>Title</DialogTitle>
           <DialogContent>
-            <Typography variant='body2'>{LIPSUM}</Typography>
+            <Typography variant='subtitle1'>{LIPSUM}</Typography>
           </DialogContent>
           <DialogActions>
             <DialogAction onClick={this.handleClose} variant='primary'>OK</DialogAction>

--- a/src/pickers/stories/usage.jsx
+++ b/src/pickers/stories/usage.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
 import { withDocs } from 'storybook-readme'
+import { ThemeProvider } from '../../styles'
+import defaultTheme from '../../styles/themes/default'
 
 import MomentUtils from '@date-io/moment'
 import { DatePicker, DateTimePicker, TimePicker } from '../..'
@@ -28,8 +30,10 @@ const changeDate = (momentDate) => {
 
 export default withDocs(md, () =>
   <GridLayout>
-    <DatePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
-    <TimePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
-    <DateTimePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
+    <ThemeProvider theme={defaultTheme()}>
+      <DatePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
+      <TimePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
+      <DateTimePicker dateManagementLibrary={MomentUtils} onChange={changeDate} />
+    </ThemeProvider>
   </GridLayout>
 )


### PR DESCRIPTION
https://trello.com/c/k7EZNukl/935-add-support-for-responsive-typography-variants-to-component-library
https://trello.com/c/uEHMo2ee/1061-set-new-tcui-default-font-sizes

This is part 2 of breaking up https://github.com/conversation/ui/pull/102
It relies on https://github.com/conversation/ui/pull/103

This updates the components to use as close a typographic variant as possible. Very few of these components are documented in [Gallery](https://gallery.io/projects/MCHbtQVoQ2HCZWiQBR82z4LY), so it's picking from the [Typography variants](http://styleguide.theconversation.com/?path=/story/typography--variants) that appear visually similar.

# Comparison of components
Left is this PR, right is master

**Now**, a bunch of components needed tweaks. Most were changing a `h5` to ` h3` or so. Some will require changes on TC's end, as the components they accept (for the most part `Typography` components) will have changed font sizes. Any ones I changed the examples of will need to be updated on TC as well, after this has has been versioned.

### ArticleDonationBanner
<img width="1440" alt="ArticleDonationBanner" src="https://user-images.githubusercontent.com/127084/65403288-43d21900-de16-11e9-9839-682522bdba36.png">

### Autocomplete
<img width="1440" alt="Autocomplete" src="https://user-images.githubusercontent.com/127084/65403289-446aaf80-de16-11e9-930e-825f934e1656.png">

### Button
<img width="1440" alt="Button" src="https://user-images.githubusercontent.com/127084/65403290-446aaf80-de16-11e9-8765-4387c2c64dfd.png">

### Dialog
<img width="1440" alt="Dialog" src="https://user-images.githubusercontent.com/127084/65403291-446aaf80-de16-11e9-9c09-2261baeba128.png">

### DonationBanner
<img width="1440" alt="DonationBanner" src="https://user-images.githubusercontent.com/127084/65403292-45034600-de16-11e9-8a8c-e2686f5db49e.png">

### DonationDialog
<img width="1440" alt="DonationDialog" src="https://user-images.githubusercontent.com/127084/65403293-45034600-de16-11e9-8fc9-6d7ad703e960.png">

### Dropdown
<img width="1440" alt="Dropdown" src="https://user-images.githubusercontent.com/127084/65403294-45034600-de16-11e9-95b1-7bbcfdd49f7f.png">

### MessageTile
<img width="1440" alt="MessageTile" src="https://user-images.githubusercontent.com/127084/65403296-45034600-de16-11e9-9531-063581ad690d.png">
<img width="1440" alt="MessageTile Examples 1" src="https://user-images.githubusercontent.com/127084/65403425-fbffc180-de16-11e9-80cd-aeda379853ef.png">
<img width="1440" alt="MessageTile Examples 2" src="https://user-images.githubusercontent.com/127084/65403426-fbffc180-de16-11e9-8a2d-5538fd362797.png">

### Person
<img width="1440" alt="Person" src="https://user-images.githubusercontent.com/127084/65403297-459bdc80-de16-11e9-93c6-9d91aea14507.png">

### TextFields
<img width="1440" alt="TextFields" src="https://user-images.githubusercontent.com/127084/65403302-46347300-de16-11e9-9c66-4c0191e5a5b1.png">

### ThickBanner
<img width="1440" alt="ThinBanner" src="https://user-images.githubusercontent.com/127084/65403304-46cd0980-de16-11e9-980a-d06afaec2d96.png">

### ThinBanner
<img width="1440" alt="ThinDonationBanner" src="https://user-images.githubusercontent.com/127084/65403305-46cd0980-de16-11e9-8b15-a415edb4840a.png">

### ThinDonationBanner
<img width="1440" alt="ThickBanner" src="https://user-images.githubusercontent.com/127084/65403303-46cd0980-de16-11e9-8e13-8339d7501345.png">