### PR TITLE
Apply device-width responsive Typography variants to component library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Add responsive desktop-device font sizes to Typography component
 * Updates font sizes for Typography
 
 # 2.13.0 (2019-09-17)

--- a/src/Typography/Typography.jsx
+++ b/src/Typography/Typography.jsx
@@ -19,13 +19,19 @@ const styles = theme => ({
   h1: {
     fontFamily: 'Montserrat',
     fontWeight: 700,
-    fontSize: '1.75rem'
+    fontSize: '1.75rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '2.75rem'
+    }
   },
 
   h2: {
     fontFamily: 'Montserrat',
     fontWeight: 700,
-    fontSize: '1.625rem'
+    fontSize: '1.625rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '2rem'
+    }
   },
 
   h3: {
@@ -57,25 +63,37 @@ const styles = theme => ({
   body1: {
     fontFamily: 'Libre Baskerville',
     lineHeight: '1.5',
-    fontSize: '1rem'
+    fontSize: '1rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1.125rem'
+    }
   },
 
   body2: {
     fontFamily: 'Noto Sans',
     lineHeight: '1.5',
-    fontSize: '1.125rem'
+    fontSize: '1.125rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1.5rem'
+    }
   },
 
   button: {
     letterSpacing: 0.25,
     textTransform: 'none',
-    fontSize: '0.875rem'
+    fontSize: '0.875rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1rem'
+    }
   },
 
   overline: {
     letterSpacing: 0.25,
     textTransform: 'none',
-    fontSize: '0.875rem'
+    fontSize: '0.875rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1rem'
+    }
   },
 
   caption: {

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -1,4 +1,8 @@
 import core from '../palettes/core'
+import { createMuiTheme } from '@material-ui/core/styles'
+
+// Create a new theme to use it's default breakpoints
+const theme = createMuiTheme()
 
 export const typography = {
   fontFamily: 'Noto Sans',
@@ -7,7 +11,10 @@ export const typography = {
   button: {
     letterSpacing: 0.25,
     textTransform: 'none',
-    fontSize: '0.875rem'
+    fontSize: '0.875rem',
+    [theme.breakpoints.up('sm')]: {
+      fontSize: '1rem'
+    }
   }
 }
 


### PR DESCRIPTION
https://trello.com/c/k7EZNukl/935-add-support-for-responsive-typography-variants-to-component-library
https://trello.com/c/Cteo0DGU/1063-apply-device-width-responsive-typography-variants-to-component-library

This is part 3 of breaking up #102
It relies on #103 and #104 

This updates the `Typography` component to add desktop- breakpoint font sizes.

![responsive](https://user-images.githubusercontent.com/127084/65648600-487d1400-e046-11e9-98ec-1b31997fa375.gif)

- h1 - 28px (44px on desktop)
- h2 - 26px (32px on desktop)
- h3 - 22px
- h4 - 20px
- h5 - 18px
- h6 - 16px
- Overline - 14px (16px on desktop)
- Subtitle 1 - 16px
- Subtitle 2 - 12px
- Caption - 12px
- Button - 14px (16px on desktop)
- Body 1 - 16px (18px on desktop)
- Body 2 - 18px (24px on desktop)
