### PR TITLE
Add optional non-default click-away closes the popup functionality

### DIFF
--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -94,7 +94,7 @@ export const StickyPopup = ({
   onClose
 }) => {
   const action = dismissable ? <StickyPopupDismiss onClose={onClose} /> : null
-  const clickAwayAction = clickAwayClose ? onClose : null
+  const clickAwayAction = clickAwayClose ? onClose : () => {}
   return (
     <Snackbar
       anchorOrigin={anchorOrigin}

--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -86,6 +86,7 @@ export const StickyPopup = ({
   autoHideDuration,
   children,
   classes,
+  clickAwayClose,
   color,
   dismissable,
   open,
@@ -93,12 +94,14 @@ export const StickyPopup = ({
   onClose
 }) => {
   const action = dismissable ? <StickyPopupDismiss onClose={onClose} /> : null
+  const clickAwayAction = clickAwayClose ? onClose : null
   return (
     <Snackbar
       anchorOrigin={anchorOrigin}
       autoHideDuration={autoHideDuration}
       open={open}
       onClose={onClose}
+      ClickAwayListenerProps={{ onClickAway: clickAwayAction }}
     >
       <SnackbarContent
         classes={classes}
@@ -114,6 +117,7 @@ StickyPopup.defaultProps = {
   anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
   autoHideDuration: null,
   children: {},
+  clickAwayClose: false,
   color: 'inherit',
   dismissable: false,
   open: true,
@@ -139,6 +143,11 @@ StickyPopup.propTypes = {
   * The content of the StickyPopup.
   */
   children: PropTypes.node.isRequired,
+
+  /**
+  * Should clicking outside of the StickyPopup close it
+  */
+  clickAwayClose: PropTypes.bool,
 
   /**
    * Optional colour to override the default colour.

--- a/src/StickyPopup/StickyPopup.test.jsx
+++ b/src/StickyPopup/StickyPopup.test.jsx
@@ -5,7 +5,39 @@ import SnackbarContent from '@material-ui/core/SnackbarContent'
 import StickyPopup from './StickyPopup'
 import StickyPopupDismiss from './StickyPopupDismiss'
 
+function fireBodyMouseEvent (name, properties = {}) {
+  const event = document.createEvent('MouseEvents')
+  event.initEvent(name, true, true)
+  Object.keys(properties).forEach(key => {
+    event[key] = properties[key]
+  })
+  document.body.dispatchEvent(event)
+  return event
+}
+
 describe('<StickyPopup />', () => {
+  describe('clickAwayClose', () => {
+    it('stops StickyPopup closing if clicked away from component if false', () => {
+      const onClose = jest.fn()
+
+      const wrapper = mount(<StickyPopup onClose={onClose}>A message</StickyPopup>)
+      expect(wrapper.find('StickyPopup').props().clickAwayClose).toBe(false)
+
+      fireBodyMouseEvent('click')
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('closes StickyPopup if clicked away from component if true', () => {
+      const onClose = jest.fn()
+      const wrapper = mount(<StickyPopup onClose={onClose} clickAwayClose>A message</StickyPopup>)
+
+      expect(wrapper.find('StickyPopup').props().clickAwayClose).toBe(true)
+
+      fireBodyMouseEvent('click')
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
   describe('dismissable', () => {
     it('shows a dismiss button if prop is provided', () => {
       const onClose = jest.fn()

--- a/src/StickyPopup/stories/ClickAwayClose.jsx
+++ b/src/StickyPopup/stories/ClickAwayClose.jsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { ThemeProvider } from '../../styles'
+import { action } from '@storybook/addon-actions'
+import { GridLayout } from '../../util'
+import { withDocs } from 'storybook-readme'
+
+import Button from '../../Button'
+import Typography from '../../Typography'
+import StickyPopup from '../StickyPopup'
+
+import coreTheme from '../../styles/themes/core'
+import defaultTheme from '../../styles/themes/default'
+
+class DefaultBehaviour extends React.Component {
+  state = {
+    open: true
+  }
+
+  handleOpen = event => {
+    action('open')(event)
+    this.setState({ open: !this.state.open })
+  }
+
+  handleClose = event => {
+    action('close')(event)
+    this.setState({ open: false })
+  }
+
+  render () {
+    return (
+      <ThemeProvider theme={coreTheme()}>
+        <Button
+          colour='primary'
+          onClick={this.handleOpen}
+          style={{ clear: 'both', margin: '16px 0' }}
+        >Show ClickAwayClose="false" StickyPopup</Button>
+
+        <StickyPopup
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left'
+          }}
+          color='primary'
+          dismissable
+          onClose={this.handleClose}
+          open={this.state.open}
+          prominent
+        >
+          <Typography variant='h3'>
+            This StickyPopup does not close if you click outside of it.
+          </Typography>
+
+          <Typography variant='h6'>
+            This is the default behaviour.
+          </Typography>
+        </StickyPopup>
+      </ThemeProvider>
+    )
+  }
+};
+
+class OptionalBehaviour extends React.Component {
+  state = {
+    open: true
+  }
+
+  handleOpen = event => {
+    action('open')(event)
+    this.setState({ open: !this.state.open })
+  }
+
+  handleClose = event => {
+    action('close')(event)
+    this.setState({ open: false })
+  }
+
+  render () {
+    return (
+      <ThemeProvider theme={defaultTheme()}>
+        <Button
+          colour='primary'
+          onClick={this.handleOpen}
+          style={{ clear: 'both', margin: '16px 0' }}
+        >Show ClickAwayClose="true" StickyPopup</Button>
+
+        <StickyPopup
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right'
+          }}
+          clickAwayClose
+          color='primary'
+          dismissable
+          onClose={this.handleClose}
+          open={this.state.open}
+          prominent
+        >
+          <Typography variant='h3'>
+            This StickyPopup closes if you click outside of it.
+          </Typography>
+
+          <Typography variant='h6'>
+            This is <em>optional</em> behaviour.
+          </Typography>
+        </StickyPopup>
+      </ThemeProvider>
+    )
+  }
+}
+
+const md = `
+# ClickAwayClose
+
+The \`clickAwayClose\` boolean flag _by-default_ disables the click away handlers
+that the underlying component (the SnackBar) build by default.
+
+
+* if \`clickAwayClose\` is \`false\`, which is the default, it disables the click away handlers
+* if \`clickAwayClose\` is \`true\`, it calls the \`onClose\` function when clicked outside of
+the \`StickyPopup\` component.
+
+## Example
+
+<!-- STORY -->
+`
+
+export default withDocs(md, () =>
+  <GridLayout>
+    <DefaultBehaviour />
+    <OptionalBehaviour />
+  </GridLayout>
+)

--- a/src/StickyPopup/stories/index.jsx
+++ b/src/StickyPopup/stories/index.jsx
@@ -2,7 +2,9 @@ import { storiesOf } from '@storybook/react'
 
 import StickyPopup from './StickyPopup'
 import Examples from './Examples'
+import ClickAwayClose from './ClickAwayClose'
 
 storiesOf('StickyPopup', module)
   .add('Overview', StickyPopup)
   .add('Examples', Examples)
+  .add('Click-away close', ClickAwayClose)


### PR DESCRIPTION
https://trello.com/c/lSKswxhI/1081-add-optional-non-default-click-away-closes-the-popup-functionality

The StickyPopup (more specifically, the underlying Snackbar) by-default had behaviour that clicking away closed the popup.

This is because it wasn't _meant_ to have a dismissable "X". 
No problem!

So, now, by default the click away handlers do nothing.
We can also optionally set them to when clicked away, it closes the StickyPopup.

To view, http://localhost:9001/?path=/story/stickypopup--click-away-close
