### PR TITLE
Sticky popup related fixes

### DIFF
--- a/src/StickyPopup/StickyPopup.jsx
+++ b/src/StickyPopup/StickyPopup.jsx
@@ -31,8 +31,8 @@ const styles = theme => ({
       false: theme.spacing(1)
     }),
     margin: '0 auto',
-    paddingRight: theme.spacing(2),
-    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(3),
+    paddingLeft: theme.spacing(3),
     textAlign: 'center',
     maxWidth: 360,
     display: 'flex',

--- a/src/StickyPopup/stories/Examples.jsx
+++ b/src/StickyPopup/stories/Examples.jsx
@@ -55,7 +55,7 @@ class RepublishingStickyPopup extends React.Component {
           </Typography>
 
           <Button variant='contained' color='secondary' onClick={action('click')}>
-            Republsh this article
+            Republish this article
           </Button>
         </StickyPopup>
       </ThemeProvider>
@@ -97,11 +97,11 @@ class DonationStickyPopup extends React.Component {
           onClose={this.handleClose}
           open={this.state.open}
         >
-          <Typography variant='subtitle2'>
+          <Typography variant='subtitle1'>
             The Conversation provides clean information in a world infected with spin.
           </Typography>
 
-          <Button variant='contained' onClick={action('click')}>
+          <Button variant='text' color='inherit' onClick={action('click')}>
             Donate now
           </Button>
         </StickyPopup>
@@ -143,13 +143,12 @@ class NewsletterStickyPopup extends React.Component {
           dismissable
           onClose={this.handleClose}
           open={this.state.open}
-          prominent
         >
-          <Typography variant='h5'>
+          <Typography variant='subtitle1'>
             Join over 100,000 Australians who value free evidence-based news.
           </Typography>
 
-          <Button variant='contained' color='secondary' onClick={action('click')}>
+          <Button variant='text' color='inherit' onClick={action('click')}>
             Sign up today
           </Button>
         </StickyPopup>

--- a/src/Typography/Typography.jsx
+++ b/src/Typography/Typography.jsx
@@ -79,7 +79,6 @@ const styles = theme => ({
   },
 
   button: {
-    letterSpacing: 0.25,
     textTransform: 'none',
     fontSize: '0.875rem',
     [theme.breakpoints.up('sm')]: {

--- a/src/Typography/Typography.jsx
+++ b/src/Typography/Typography.jsx
@@ -100,7 +100,8 @@ const styles = theme => ({
   },
 
   subtitle1: {
-    fontSize: '1rem'
+    fontSize: '1rem',
+    lineHeight: '1.3'
   },
 
   subtitle2: {

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -11,6 +11,7 @@ export const typography = {
   button: {
     textTransform: 'none',
     fontSize: '0.875rem',
+    fontWeight: 700,
     [theme.breakpoints.up('sm')]: {
       fontSize: '1rem'
     }

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -9,7 +9,6 @@ export const typography = {
   fontSize: 16,
 
   button: {
-    letterSpacing: 0.25,
     textTransform: 'none',
     fontSize: '0.875rem',
     [theme.breakpoints.up('sm')]: {


### PR DESCRIPTION
After trying out the `StickyPopup` in TC for real, we found a few minor issues that are worth fixing before we ship it.

 - Removed letter spacing from `button` typography variant
 - Ensured button text is bold as intended
 - Set line height of `subtitle1` to 1.3 so it's not as spaced out
 - Increased the padding to prevent text from slamming against the "x" button
 - Updated examples to closer match mockups

Before:
![Screenshot at 2019-10-09 17-36-28](https://user-images.githubusercontent.com/2295892/66457149-5f4a4e80-eabb-11e9-92de-65721b1d44e2.png)

After:
![Screenshot at 2019-10-09 17-37-29](https://user-images.githubusercontent.com/2295892/66457182-7ab55980-eabb-11e9-87af-d4f339978ee0.png)

