### PR TITLE
Update UI Docs to reflect example

### DIFF
--- a/src/DonationDialog/DonationDialog.jsx
+++ b/src/DonationDialog/DonationDialog.jsx
@@ -86,7 +86,7 @@ const styles = theme => ({
  *   <DialogAvatar src={koala} />
  *   <DialogInlineTitle>Support close combat training for koalas</DialogInlineTitle>
  *   <DialogContent>
- *     <Typography variant='body1'>{content}</Typography>
+ *     <Typography variant='subtitle1'>{content}</Typography>
  *     <MiniDivider />
  *     <Person name="Colonel Koala" caption="Leader of the Koala Freedom Collective" />
  *   </DialogContent>


### PR DESCRIPTION
Looks like docs went stale

The example uses `substitle1` not body, so we should reflect that in the docs.

- Note: I haven't updated the CHANGELOG in this because the current changelog accurately reflects the current state.