### PR TITLE
Change MessageTileHeader from h3 to h5 to bring it into line with designs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Update docs in example
+* Change MessageTileHeader from h3 to h5
 
 # 2.16.0 (2019-10-09)
 

--- a/src/MessageTile/MessageTileHeader.jsx
+++ b/src/MessageTile/MessageTileHeader.jsx
@@ -11,7 +11,7 @@ const styles = theme => ({
 
 export const MessageTileHeader = ({ children, classes }) => {
   return (
-    <Typography className={classes.title} variant='h3'>
+    <Typography className={classes.title} variant='h5'>
       { children }
     </Typography>
   )


### PR DESCRIPTION
https://trello.com/c/R6Tj8iLT/1329-change-messagetileheader-from-h3-to-h5-to-bring-it-into-line-with-designs

To bring the MessageTile inline with @ZoeJazz's designs, we need to bump the
heading down a smidge to h5.

Raised inhttps://github.com/conversation/tc/pull/9348#issuecomment-549190088

Left is master, right is this PR:
![Screen Shot 2019-11-04 at 11 04 21 am (3)](https://user-images.githubusercontent.com/127084/68094311-1e472d80-fef3-11e9-8154-f422a5ce2980.png)


And the docs to match them against: https://gallery.io/projects/MCHbtQVoQ2HCZWiQBR82z4LY/files/MCEJu8Y2hyDScTrgA6mNBmQtHZ7tLvHQhN0
