### PR TITLE
Change MessageTile padding to 24px 16px 16px 16px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update docs in example
 * Change MessageTileHeader from h3 to h5
+* Minor padding change to MessageTile
 
 # 2.16.0 (2019-10-09)
 

--- a/src/MessageTile/MessageTile.jsx
+++ b/src/MessageTile/MessageTile.jsx
@@ -9,7 +9,10 @@ const styles = theme => ({
   box: {
     borderRadius: theme.spacing(0.5),
     marginBottom: theme.spacing(2),
-    padding: theme.spacing(2)
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(2),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2)
   }
 })
 


### PR DESCRIPTION
https://trello.com/c/fw5FrrXi/1330-change-messagetiles-spacing-to-top-bottom-24px-and-left-right-16px

*Why*

We want overall spacing of the `MessageTile` to be 24px/16px. We need to factor in that internal components have their own margin (to space themselves appropriately), and need to factor that in.

*How*
We use consistent multiples of 4px as base units, so by changing the
`MessageTile`'s padding top/bottom to 24px/16px, the last component's margin-bottom (all of them are 8px) would push down 8px, and the outer component pads the bottom 16px (making 24px... 8px + 16px = 24px, matching the padding-top).

![Artboard](https://user-images.githubusercontent.com/127084/68355321-fd850f00-0162-11ea-8ba2-c7e1f996edc9.png)

Left is master, right is this PR (note the _slight_ change to the spacing on all `MessageTile` examples.
![Artboard](https://user-images.githubusercontent.com/127084/68359623-a38b4600-0170-11ea-8d50-81675544d170.png)


**Also note** that the one with Misha's attribution isn't quite right (it's not the same size as the others). I'll look at implenting a `MessageTileFooter` component to wrap up whatever would go there, and give it margin as well like the other `MessageTile` sub-components. The discussion is here (https://github.com/conversation/ui/pull/112#issuecomment-549319190), and that'll be a separate PR.