### PR TITLE
Create a MessageTileFooter component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Update docs in example
 * Change MessageTileHeader from h3 to h5
+* Add MessageTileFooter sub-component
 
 # 2.16.0 (2019-10-09)
 

--- a/src/MessageTile/MessageTile.jsx
+++ b/src/MessageTile/MessageTile.jsx
@@ -19,24 +19,43 @@ const styles = theme => ({
  * call-to-action button at the bottom.
  *
  * ```js
- * import { MessageTile, MessageTileHeader, MessageTileBody, MessageTileButton } from '@theconversation/ui'
+ * import {
+ *   MessageTile,
+ *   MessageTileHeader,
+ *   MessageTileBody,
+ *   MessageTileButton,
+ *   MessageTileFooter,
+ *   Avatar,
+ *   Person,
+ *   Typography
+ * } from '@theconversation/ui'
  *
  * <MessageTile>
- *  <MessageTileHeader>
- *    <img style={{ width: 26, marginRight: 6, marginBottom: 8 }} src={by} />
- *    <img style={{ width: 26, marginRight: 6, marginBottom: 8 }} src={cc} />
- *    <img style={{ width: 26, marginBottom: 8 }} src={nd} />
- *    <div>We believe in the free flow of information.</div>
- *  </MessageTileHeader>
+ *   <MessageTileHeader>
+ *     Before you go...
+ *   </MessageTileHeader>
  *
- *  <MessageTileBody>
- *    All our articles can be republished for free, online or in print, under the Creative Commons licence.
- *  </MessageTileBody>
-
- *  <MessageTileButton onClick={action('clicked')}>
- *    Republish for free
- *  </MessageTileButton>
- *</MessageTile>
+ *   <MessageTileBody>
+ *     <Typography variant='body1' paragraph>
+ *       It is easier than ever before for vested interests to spread
+ *       disinformation on vital matters of public interest. If you want
+ *       to know what's really going you need to hear from the experts
+ *       willing to drill down to the truth. But we can't do that vital
+ *       work unless readers donate. Please make a donation.
+ *     </Typography>
+ *   </MessageTileBody>
+ *
+ *   <MessageTileButton fullWidth={false} prominent onClick={action('clicked')}>
+ *     Donate now
+ *   </MessageTileButton>
+ *
+ *    <MessageTileFooter>
+ *      <Typography gutterBottom>
+ *        <Person name='Misha Ketchell' caption='Editor' />
+ *      </Typography>
+ *      <Avatar size={48} src='https://cdn.theconversation.com/avatars/13/width238/image-20181205-186070-f58pk2.jpg' />
+ *    </MessageTileFooter>
+ *  </MessageTile>
  * ```
  *
  * You can change the internal styling by wrapping the whole thing in a `ThemeProvider`

--- a/src/MessageTile/MessageTileFooter.jsx
+++ b/src/MessageTile/MessageTileFooter.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import withStyles from '@material-ui/core/styles/withStyles'
+
+const styles = theme => ({
+  footer: {
+    marginBottom: theme.spacing(1)
+  }
+})
+
+export const MessageTileFooter = ({ children, classes }) => {
+  return (
+    <div className={classes.footer} key='footer'>
+      {children}
+    </div>
+  )
+}
+
+MessageTileFooter.defaultTypes = {
+  children: {}
+}
+
+MessageTileFooter.propTypes = {
+  /**
+   * The nested components that go in the body
+   */
+  children: PropTypes.node.isRequired
+}
+
+export default withStyles(styles)(MessageTileFooter)

--- a/src/MessageTile/MessageTileFooter.test.jsx
+++ b/src/MessageTile/MessageTileFooter.test.jsx
@@ -1,0 +1,13 @@
+import MessageTileFooter from './MessageTileFooter'
+import React from 'react'
+import { mount } from 'enzyme'
+
+describe('<MessageTileFooter />', () => {
+  describe('children', () => {
+    it('is rendered inside a div', () => {
+      const wrapper = mount(<MessageTileFooter>Name and Job</MessageTileFooter>)
+
+      expect(wrapper.find('div').text()).toEqual('Name and Job')
+    })
+  })
+})

--- a/src/MessageTile/stories/examples.jsx
+++ b/src/MessageTile/stories/examples.jsx
@@ -5,6 +5,7 @@ import MessageTile from '../MessageTile'
 import MessageTileHeader from '../MessageTileHeader'
 import MessageTileBody from '../MessageTileBody'
 import MessageTileButton from '../MessageTileButton'
+import MessageTileFooter from '../MessageTileFooter'
 import { action } from '@storybook/addon-actions'
 
 import Avatar from '../../Avatar'
@@ -101,12 +102,12 @@ export default () => (
             Donate now
           </MessageTileButton>
 
-          <div key='attribution'>
+          <MessageTileFooter>
             <Typography gutterBottom>
               <Person name='Misha Ketchell' caption='Editor' />
             </Typography>
             <Avatar size={48} src='https://cdn.theconversation.com/avatars/13/width238/image-20181205-186070-f58pk2.jpg' />
-          </div>
+          </MessageTileFooter>
         </MessageTile>
       </ThemeProvider>
     </div>

--- a/src/MessageTile/stories/index.jsx
+++ b/src/MessageTile/stories/index.jsx
@@ -4,6 +4,7 @@ import examples from './examples'
 import messageTileHeader from './messageTileHeader'
 import messageTileBody from './messageTileBody'
 import messageTileButton from './messageTileButton'
+import messageTileFooter from './messageTileFooter'
 
 storiesOf('MessageTile', module)
   .add('Overview', messageTile)
@@ -11,3 +12,4 @@ storiesOf('MessageTile', module)
   .add('MessageTileHeader', messageTileHeader)
   .add('MessageTileBody', messageTileBody)
   .add('MessageTileButton', messageTileButton)
+  .add('MessageTileFooter', messageTileFooter)

--- a/src/MessageTile/stories/messageTile.jsx
+++ b/src/MessageTile/stories/messageTile.jsx
@@ -5,33 +5,45 @@ import MessageTile, { MessageTile as UnwrappedMessageTile } from '../MessageTile
 import MessageTileHeader from '../MessageTileHeader'
 import MessageTileBody from '../MessageTileBody'
 import MessageTileButton from '../MessageTileButton'
+import MessageTileFooter from '../MessageTileFooter'
+
+import coreTheme from '../../styles/themes/core'
+
+import Avatar from '../../Avatar'
+import Person from '../../Person'
+import Typography from '../../Typography'
+
 import { action } from '@storybook/addon-actions'
-
-import by from './by.svg'
-import cc from './cc.svg'
-import nd from './nd.svg'
-
-import defaultTheme from '../../styles/themes/default'
 
 export default () => (
   <ComponentOverview heading='MessageTile' component={UnwrappedMessageTile}>
-    <div style={{ marginTop: 16, width: 220 }}>
-      <ThemeProvider theme={defaultTheme()}>
+    <div style={{ marginTop: 16, width: 552 }}>
+      <ThemeProvider theme={coreTheme()}>
         <MessageTile>
           <MessageTileHeader>
-            <img style={{ width: 26, marginRight: 6, marginBottom: 8 }} src={by} />
-            <img style={{ width: 26, marginRight: 6, marginBottom: 8 }} src={cc} />
-            <img style={{ width: 26, marginBottom: 8 }} src={nd} />
-            <div>We believe in the free flow of information.</div>
+            Before you go...
           </MessageTileHeader>
 
           <MessageTileBody>
-            All our articles can be republished for free, online or in print, under the Creative Commons licence.
+            <Typography variant='body1' paragraph>
+              It is easier than ever before for vested interests to spread
+              disinformation on vital matters of public interest. If you want
+              to know what's really going you need to hear from the experts
+              willing to drill down to the truth. But we can't do that vital
+              work unless readers donate. Please make a donation.
+            </Typography>
           </MessageTileBody>
 
-          <MessageTileButton onClick={action('clicked')}>
-            Republish for free
+          <MessageTileButton fullWidth={false} prominent onClick={action('clicked')}>
+            Donate now
           </MessageTileButton>
+
+          <MessageTileFooter>
+            <Typography gutterBottom>
+              <Person name='Misha Ketchell' caption='Editor' />
+            </Typography>
+            <Avatar size={48} src='https://cdn.theconversation.com/avatars/13/width238/image-20181205-186070-f58pk2.jpg' />
+          </MessageTileFooter>
         </MessageTile>
       </ThemeProvider>
     </div>

--- a/src/MessageTile/stories/messageTileFooter.jsx
+++ b/src/MessageTile/stories/messageTileFooter.jsx
@@ -1,0 +1,24 @@
+import ComponentOverview from '../../ComponentOverview'
+import React from 'react'
+import { ThemeProvider } from '../../styles'
+import Typography from '../../Typography'
+import Avatar from '../../Avatar'
+import Person from '../../Person'
+import MessageTileFooter, { MessageTileFooter as UnwrappedMessageTileFooter } from '../MessageTileFooter'
+
+import defaultTheme from '../../styles/themes/default'
+
+export default () => (
+  <ComponentOverview heading='MessageTileFooter' component={UnwrappedMessageTileFooter}>
+    <div style={{ width: 220 }}>
+      <ThemeProvider theme={defaultTheme()}>
+        <MessageTileFooter>
+          <Typography gutterBottom>
+            <Person name='Misha Ketchell' caption='Editor' />
+          </Typography>
+          <Avatar size={48} src='https://cdn.theconversation.com/avatars/13/width238/image-20181205-186070-f58pk2.jpg' />
+        </MessageTileFooter>
+      </ThemeProvider>
+    </div>
+  </ComponentOverview>
+)


### PR DESCRIPTION
*Why*

We have an ad-hoc `div` in the storybook examples and in TC's `EndOfArticle`, with no styling.
To make it like the `MessageTileButton` component and have the same consistent margin-bottom to push down the bottom of it's parent (explained in https://github.com/conversation/ui/pull/114), I've made a new component to sit in this spot.

Left is master (with unstyled divs), right is this PR (using the sub-component)
![Artboard](https://user-images.githubusercontent.com/127084/68360383-f74b5e80-0173-11ea-8a0f-957300659185.png)

Following on from discussion at https://github.com/conversation/ui/pull/112#issuecomment-549319190
