### PR TITLE
Add resets to heading typography variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Add stylesheet property resets to heading variants of Typography
+
 # 2.17.0 (2019-11-07)
 
 * Adds a ThemeSelector component

--- a/src/Typography/Typography.jsx
+++ b/src/Typography/Typography.jsx
@@ -15,8 +15,25 @@ import withStyles from '@material-ui/core/styles/withStyles'
  * </Typography>
  * ~~~
  */
+
+// Default overrides which prevent TC's legacy top level styles from having
+// a negative impact on typography components.
+//
+// Note that some properties have been skipped intentionally, such as margin.
+//
+// The margin is set via a different class on a Typography by MUI itself, which
+// is already specific enough to override TC's styles. Including a reset
+// for those properties (margin, color, etc) would cause more harm than good.
+const LEGACY_HEADING_RESETS = {
+  fontSize: 'initial',
+  fontWeight: 'initial',
+  textTransform: 'initial',
+  letterSpacing: 'initial'
+}
+
 const styles = theme => ({
   h1: {
+    ...LEGACY_HEADING_RESETS,
     fontFamily: 'Montserrat',
     fontWeight: 700,
     fontSize: '1.75rem',
@@ -26,6 +43,7 @@ const styles = theme => ({
   },
 
   h2: {
+    ...LEGACY_HEADING_RESETS,
     fontFamily: 'Montserrat',
     fontWeight: 700,
     fontSize: '1.625rem',
@@ -35,24 +53,28 @@ const styles = theme => ({
   },
 
   h3: {
+    ...LEGACY_HEADING_RESETS,
     fontFamily: 'Montserrat',
     fontWeight: 700,
     fontSize: '1.375rem'
   },
 
   h4: {
+    ...LEGACY_HEADING_RESETS,
     fontFamily: 'Montserrat',
     fontWeight: 600,
     fontSize: '1.25rem'
   },
 
   h5: {
+    ...LEGACY_HEADING_RESETS,
     fontFamily: 'Montserrat',
     fontWeight: 600,
     fontSize: '1.125rem'
   },
 
   h6: {
+    ...LEGACY_HEADING_RESETS,
     fontFamily: 'Montserrat',
     fontWeight: 700,
     lineHeight: 'normal',


### PR DESCRIPTION
This isn't ideal, but it was far harder than expected to quarantine TC's styles. (biggest blocker and bordering on impossible to change at the moment is the content pipeline). This ended up being the easiest way to prevent TC's legacy CSS from messing with MUI typography heading variants.

Initially I planned to reset every property that we set in TC (like the trello card mentions), but that caused additional problems due to class specificity and the way MUI mixes classes together to build the styles for Typography components.

In the end, I experimented until I only had resets for just the properties that were likely to cause (and have caused) the most grief while effectively being a no-op visually - so if you are testing locally, you shouldn't see any visual differences in this PR.

This may mean we could encounter problems in less travelled parts of TC, but we can always add more resets if needed.