### PR TITLE
Change example of MessageTile to have match how it's implemented on TC

### DIFF
--- a/src/MessageTile/stories/examples.jsx
+++ b/src/MessageTile/stories/examples.jsx
@@ -41,8 +41,8 @@ export default () => (
             All our articles can be republished for free, online or in print, under the Creative Commons licence.
           </MessageTileBody>
 
-          <MessageTileButton onClick={action('clicked')}>
-            Republish for free
+          <MessageTileButton size='small' onClick={action('clicked')}>
+            Republish this article
           </MessageTileButton>
         </MessageTile>
       </ThemeProvider>


### PR DESCRIPTION
https://trello.com/c/CfgJGmwb/1421-show-use-of-sizesmall-button-on-republishpanel-examples

**Why**

The MessageTile was designed for text of the length "Republish for free", but implemented on TC with "Republish this article".

This caused some line wrapping, so we decided to use the `small` variant of the `Button`.

This _only_ changes the example in Storybook. The changes are already implemented on TC.

**Before**
![Screen Shot 2019-11-14 at 1 35 40 pm](https://user-images.githubusercontent.com/127084/68822373-dee3c280-06e4-11ea-94a0-da1a046642d3.png)

**After**
![Screen Shot 2019-11-14 at 1 35 48 pm](https://user-images.githubusercontent.com/127084/68822374-dee3c280-06e4-11ea-815a-d476e4464a1a.png)
