### PR TITLE
Add tree shaking support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ node_modules:
 	@npm install
 
 dist:
-	@npx babel --copy-files --out-dir dist src
+	@npm run build
 
 test:
 	@npx jest

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,15 @@
 module.exports = api => {
-  const env = api.cache(() => process.env.NODE_ENV)
-  const ignore = env === 'test' ? [] : [/test\.jsx?$/]
+  const nodeEnv = api.cache(() => process.env.NODE_ENV)
+  const ignore = nodeEnv === 'test' ? [] : [/test\.jsx?$/]
   const presets = ['@babel/preset-env', '@babel/preset-react']
   const plugins = ['@babel/plugin-proposal-class-properties']
+  const env = {
+    esm: {
+      presets: [
+        ['@babel/preset-env', { modules: false }], '@babel/preset-react'
+      ]
+    }
+  }
 
-  return { ignore, plugins, presets }
+  return { ignore, plugins, presets, env }
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,12 @@
     "component",
     "ui"
   ],
-  "main": "dist/index.js",
+  "main": "dist/cjs",
+  "module": "dist/esm",
   "scripts": {
-    "prepare": "babel --out-dir dist src"
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "babel --delete-dir-on-start --copy-files --out-dir dist/cjs src",
+    "build:esm": "babel --delete-dir-on-start --copy-files --env-name esm --out-dir dist/esm src"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
   "standard": {
     "env": "jest",
     "parser": "babel-eslint"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Right now when using any single component from this library, you get everything but the kitchen sink whether you like it or not, which isn't ideal.

With a couple of tweaks we can let webpack at least discard parts that don't actually get used with [tree shaking](https://webpack.js.org/guides/tree-shaking/).

In the following screenshots you can see (we've got a lot of work to do... but anyway) that when part of the ui library doesn't get used, it drops out of the bundle automatically. In this example, it's what happens when you don't use the datepicker.

![Screenshot at 2020-08-31 16-45-07](https://user-images.githubusercontent.com/2295892/91690571-887b3e00-eba9-11ea-8998-c923df4d9fc6.png)
