### PR TITLE
Allow donation dialog to pass props to Material UI's dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Allow passing custom props to MUI's Dialog on `DonationDialog`
+
 # 2.21.0 (2020-09-07)
 
 * Update "The Conversation" and "La Conversation" SVGs

--- a/src/DonationDialog/DonationDialog.jsx
+++ b/src/DonationDialog/DonationDialog.jsx
@@ -102,20 +102,22 @@ export const DonationDialog = ({
   onClick,
   onClose,
   onVisible,
-  open
+  open,
+  dialogProps
 }) => {
-  const dialogProps = {
+  const materialDialogProps = {
     open,
     onClose,
     onEnter: onVisible,
     classes: {
       container: classes.container,
       paper: classes.paper
-    }
+    },
+    ...dialogProps
   }
 
   return (
-    <MaterialDialog {...dialogProps}>
+    <MaterialDialog {...materialDialogProps}>
       <MaterialDialogActions className={classes.topActions}>
         <MaterialIconButton color='inherit' className={classes.close} onClick={onClose} aria-label={closeText}>
           <CloseIcon />
@@ -165,7 +167,12 @@ DonationDialog.propTypes = {
   /**
    * Accessibility alt text that is associated with the close icon button.
    */
-  closeText: PropTypes.string
+  closeText: PropTypes.string,
+
+  /**
+   * Props that will be forwarded to the Material UI dialog
+   */
+  dialogProps: PropTypes.object
 }
 
 DonationDialog.defaultProps = {


### PR DESCRIPTION
**Why?**

We want to edit our donation dialog target container, instead of always appending it to `document.body` [1]

[1] https://material-ui.com/api/modal/#props