### PR TITLE
Max characters client side validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Allow text fields to have max length validation with character count
+
 # 2.22.0 (2020-10-02)
 
 * Allow passing custom props to MUI's Dialog on `DonationDialog`

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -67,6 +67,7 @@ export const TextField = ({
   label,
   required,
   maxLength,
+  maxLengthCountText,
   ...other
 }) => {
   const [errorState, setErrorState] = useState(error)
@@ -75,7 +76,7 @@ export const TextField = ({
   // Max length validation with character count
   const [characterCount, setCharacterCount] = useState(0)
   const hasLengthValidation = maxLength > 0
-  const maxValidationHelperText = `${characterCount}/${maxLength}`
+  const maxValidationHelperText = `${characterCount}/${maxLength} ${maxLengthCountText}`
   const showHelperText = helperText || hasLengthValidation
 
   useEffect(() => {
@@ -219,6 +220,11 @@ TextField.propTypes = {
   maxLength: PropTypes.number,
 
   /**
+   * Text to be placed at the right side of character count. Example: `5/10 characters`
+   */
+  maxLengthCountText: PropTypes.string,
+
+  /**
    * The type of the text field.
    */
   type: PropTypes.oneOf(['email', 'text', 'password', 'number']),
@@ -235,6 +241,7 @@ TextField.defaultProps = {
   error: false,
   fullWidth: false,
   maxLength: 0,
+  maxLengthCountText: '',
   required: false,
   type: 'text'
 }

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -54,7 +54,6 @@ const styles = theme => {
  * ```
  */
 export const TextField = ({
-  InputProps,
   autoComplete,
   disabled,
   error,

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -14,6 +14,11 @@ const styles = theme => {
   const borderColor = light ? 'rgba(0, 0, 0, 0.42)' : 'rgba(255, 255, 255, 0.7)'
 
   return {
+    // This is a bit confusing when you first look at it, but what we're doing here
+    // is treating the subcomponent InputBase as the root component so that we can
+    // take advantage of it's named css rules.
+    //
+    // https://material-ui.com/api/input-base/#css
     root: {
       backgroundColor: theme.palette.common.white,
       border: `1px solid ${borderColor}`,
@@ -23,14 +28,6 @@ const styles = theme => {
         duration: theme.transitions.duration.shorter
       })
     },
-    formControl: {
-      'label + &': {
-        marginTop: 8
-      },
-      '& + .MuiFormHelperText-root': {
-        lineHeight: '1.5'
-      }
-    },
     focused: {
       borderColor: theme.palette.primary.main
     },
@@ -39,6 +36,14 @@ const styles = theme => {
     },
     input: {
       padding: '10px 12px'
+    },
+    // From here on these are custom styles for components which are not descendents
+    // of InputBase.
+    formLabel: {
+      marginBottom: 8
+    },
+    formHelperText: {
+      lineHeight: '1.5'
     }
   }
 }
@@ -59,6 +64,7 @@ const styles = theme => {
  */
 export const TextField = ({
   autoComplete,
+  classes,
   disabled,
   error,
   fullWidth,
@@ -116,15 +122,15 @@ export const TextField = ({
   return (
     <FormControl aria-describedby={helperTextId} disabled={disabled} error={errorState} fullWidth={fullWidth}>
       {label && (
-        <FormLabel htmlFor={id} required={required}>
+        <FormLabel className={classes.formLabel} htmlFor={id} required={required}>
           {label}
         </FormLabel>
       )}
 
-      <InputBase {...other} autoComplete={autoComplete} id={id} onChange={onChange} />
+      <InputBase {...other} classes={classes} autoComplete={autoComplete} id={id} onChange={onChange} />
 
       {showHelperText && (
-        <FormHelperText id={helperTextId}>
+        <FormHelperText id={helperTextId} className={classes.formHelperText}>
           <Grid component='span' justify='space-between' container spacing={2}>
             <Grid component='span' item xs>{helperText}</Grid>
             {hasLengthValidation && (

--- a/src/TextField/TextField.test.jsx
+++ b/src/TextField/TextField.test.jsx
@@ -79,6 +79,14 @@ describe('<TextField />', () => {
     })
   })
 
+  describe('without the helper text', () => {
+    it('does not render the FormHelperText', () => {
+      const wrapper = mount(<TextField />)
+
+      expect(wrapper.find(FormHelperText)).toHaveLength(0)
+    })
+  })
+
   describe('events', () => {
     describe('when changed', () => {
       it('calls the callback', () => {
@@ -105,6 +113,38 @@ describe('<TextField />', () => {
         wrapper.find('input').simulate('blur')
         expect(onBlur).toHaveBeenCalled()
       })
+    })
+  })
+
+  describe('without max length validation', () => {
+    it('does not render the character count', () => {
+      const wrapper = mount(<TextField helperText='I am a text field' />)
+
+      expect(wrapper.text()).toEqual('I am a text field')
+    })
+  })
+
+  describe('with max length validation', () => {
+    describe('counts text field default value length', () => {
+      it('counts the defaultValue prop', () => {
+        const wrapper = mount(<TextField defaultValue='Hello world' maxLength={20} />)
+
+        expect(wrapper.text()).toContain('11/20')
+      })
+
+      it('counts the value prop', () => {
+        const wrapper = mount(<TextField value='Hello world' maxLength={20} />)
+
+        expect(wrapper.text()).toContain('11/20')
+      })
+    })
+
+    it('marks the form control with an error if input length is above limit', () => {
+      const wrapper = mount(<TextField maxLength={5} />)
+
+      wrapper.find('input').simulate('change', { target: { value: 'I am bigger than 5 characters' } })
+
+      expect(wrapper.find(FormControl).prop('error')).toEqual(true)
     })
   })
 })

--- a/src/TextField/TextField.test.jsx
+++ b/src/TextField/TextField.test.jsx
@@ -146,5 +146,11 @@ describe('<TextField />', () => {
 
       expect(wrapper.find(FormControl).prop('error')).toEqual(true)
     })
+
+    it('renders the maxLengthCountText prop', () => {
+      const wrapper = mount(<TextField maxLength={5} maxLengthCountText='Characters' />)
+
+      expect(wrapper.text()).toContain('0/5 Characters')
+    })
   })
 })

--- a/src/TextField/stories/states.jsx
+++ b/src/TextField/stories/states.jsx
@@ -65,6 +65,7 @@ export default withDocs(md, () =>
       onChange={action('change')}
       placeholder='Placeholder text'
       maxLength={10}
+      maxLengthCountText='characters'
     />
   </GridLayout>
 )

--- a/src/TextField/stories/states.jsx
+++ b/src/TextField/stories/states.jsx
@@ -59,5 +59,12 @@ export default withDocs(md, () =>
       onChange={action('change')}
       placeholder='Placeholder text'
     />
+    <TextField
+      helperText='Helper text'
+      label='Maximum length validation'
+      onChange={action('change')}
+      placeholder='Placeholder text'
+      maxLength={10}
+    />
   </GridLayout>
 )


### PR DESCRIPTION
**Why?**

We want to have a visual feedback of the character limit of a text field

**How?**

State management happens inside the `TextField` component, being flexible enough to work when:

- Passing the `defaultValue` or `value` prop (counting initial values)
- Input with a `helperText` prop
- `multiline` inputs

**Manual testing steps**

- Checkout this branch
- Run the storybook (e.g.: `make storybook`)
- Visit the `TextField` states story (e.g.: http://localhost:9001/?path=/story/text-fields--states)
- You should see the new "Maximum length validation" input in the "Example" field

**Screencast**

![max-length-validation-example](https://user-images.githubusercontent.com/1538066/95998412-3580e180-0e0b-11eb-80b1-c3589cab2a22.gif)
