### PR TITLE
Dropdown component value prop should accept number or string types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Allow the `Dropdown` component `value` prop to be of number or string types
+
 # 2.23.0 (2020-10-19)
 
 * Allow text fields to have max length validation with character count

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -167,7 +167,7 @@ Dropdown.propTypes = {
   /**
    * The value of the dropdown.
    */
-  value: PropTypes.string
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 }
 
 Dropdown.defaultProps = {


### PR DESCRIPTION
The `Dropdown` value prop can receive a "number" in situations where we're handling IDs.