### PR TITLE
Avoid passing non-MUI classes to MUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Avoid passing non-MUI styles to MUI
+
 # 2.25.0 (2020-11-13)
 
 * Upgrade @material-ui/core to v4.4.3

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -119,6 +119,9 @@ export const TextField = ({
     autoComplete = autoComplete ? 'on' : 'off'
   }
 
+  // Separate MUI classes to pass to MUI
+  const { formLabel, formHelperText, ...muiClasses } = classes
+
   return (
     <FormControl aria-describedby={helperTextId} disabled={disabled} error={errorState} fullWidth={fullWidth}>
       {label && (
@@ -127,7 +130,7 @@ export const TextField = ({
         </FormLabel>
       )}
 
-      <InputBase {...other} classes={classes} autoComplete={autoComplete} id={id} onChange={onChange} />
+      <InputBase {...other} classes={muiClasses} autoComplete={autoComplete} id={id} onChange={onChange} />
 
       {showHelperText && (
         <FormHelperText id={helperTextId} className={classes.formHelperText}>

--- a/src/TextField/TextField.test.jsx
+++ b/src/TextField/TextField.test.jsx
@@ -15,6 +15,22 @@ describe('<TextField />', () => {
     expect(wrapper.props().value).toBe('foo')
   })
 
+  describe('non-MUI classes', () => {
+    it('does not pass formLabel to the InputBase component', () => {
+      const wrapper = shallow(
+        <TextField />
+      ).dive().find(InputBase)
+      expect(wrapper.props().classes).not.toHaveProperty('formLabel')
+    })
+
+    it('does not pass formHelperText to the InputBase component', () => {
+      const wrapper = shallow(
+        <TextField />
+      ).dive().find(InputBase)
+      expect(wrapper.props().classes).not.toHaveProperty('formHelperText')
+    })
+  })
+
   describe('with autoComplete', () => {
     it('converts a true value to "on" for the autoComplete prop', () => {
       const wrapper = shallow(


### PR DESCRIPTION
After [upgrading material-ui](https://github.com/conversation/ui/pull/138), but before this PR, we were receiving this error (and also an analogous one for formHelperText):

> Material-UI: The key `formLabel` provided to the classes prop is not implemented in ForwardRef(InputBase).
> You can only override one of the following: root,formControl,focused,disabled,adornedStart,adornedEnd,error,marginDense,multiline,fullWidth,input,inputMarginDense,inputSelect,inputMultiline,inputTypeSearch,inputAdornedStart,inputAdornedEnd,inputHiddenLabel.
