### PR TITLE
use native select for Dropdown component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* `Dropdown` component now renders MUI native `Select` component by default
+
 # 2.25.1 (2020-11-19)
 
 * Avoid passing non-MUI styles to MUI

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -39,13 +39,10 @@ const styles = theme => {
 }
 
 /**
- * The `<Dropdown>` component allows users to select from a list of items,
- * rendering MUI's native `Select` by default. Keep in mind that non-native
- * `Select` components only allow `MenuItem` components as children.
+ * The `<Dropdown>` component allows users to select from a list of items.
  *
  * ```js
- * // Native Dropdown
- * import { MenuItem, Dropdown } from '@theconversation/ui'
+ * import { Dropdown } from '@theconversation/ui'
  *
  * <Dropdown
  *   helperText='Select a colour'
@@ -55,22 +52,6 @@ const styles = theme => {
  *   <option value='red'>Red</option>
  *   <option value='green'>Green</option>
  *   <option value='blue'>Blue</option>
- * </Dropdown>
- * ```
- *
- * ```js
- * // Non-native Dropdown
- * import { MenuItem, Dropdown } from '@theconversation/ui'
- *
- * <Dropdown
- *   helperText='Select a colour'
- *   label='Colour'
- *   onChange={alert('change')}
- *   native={false}
- * >
- *   <MenuItem value='red'>Red</MenuItem>
- *   <MenuItem value='green'>Green</MenuItem>
- *   <MenuItem value='blue'>Blue</MenuItem>
  * </Dropdown>
  * ```
  */

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -40,7 +40,7 @@ const styles = theme => {
 
 /**
  * The `<Dropdown>` component allows users to select from a list of items,
- * , rendering MUI's native `Select` by default. Keep in mind that non-native
+ * rendering MUI's native `Select` by default. Keep in mind that non-native
  * `Select` components only allow `MenuItem` components as children.
  *
  * ```js

--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -39,15 +39,34 @@ const styles = theme => {
 }
 
 /**
- * The `<Dropdown>` component allows users to select from a list of items.
+ * The `<Dropdown>` component allows users to select from a list of items,
+ * , rendering MUI's native `Select` by default. Keep in mind that non-native
+ * `Select` components only allow `MenuItem` components as children.
  *
  * ```js
-  * import { MenuItem, Dropdown } from '@theconversation/ui'
-  *
+ * // Native Dropdown
+ * import { MenuItem, Dropdown } from '@theconversation/ui'
+ *
  * <Dropdown
  *   helperText='Select a colour'
  *   label='Colour'
  *   onChange={alert('change')}
+ * >
+ *   <option value='red'>Red</option>
+ *   <option value='green'>Green</option>
+ *   <option value='blue'>Blue</option>
+ * </Dropdown>
+ * ```
+ *
+ * ```js
+ * // Non-native Dropdown
+ * import { MenuItem, Dropdown } from '@theconversation/ui'
+ *
+ * <Dropdown
+ *   helperText='Select a colour'
+ *   label='Colour'
+ *   onChange={alert('change')}
+ *   native={false}
  * >
  *   <MenuItem value='red'>Red</MenuItem>
  *   <MenuItem value='green'>Green</MenuItem>
@@ -144,6 +163,11 @@ Dropdown.propTypes = {
   label: PropTypes.string,
 
   /**
+   * Defines if the Dropdown will be rendered as native.
+   */
+  native: PropTypes.bool,
+
+  /**
    * The callback function called when the dropdown value changes.
    */
   onChange: PropTypes.func,
@@ -174,6 +198,7 @@ Dropdown.defaultProps = {
   disabled: false,
   error: false,
   fullWidth: false,
+  native: true,
   required: false
 }
 

--- a/src/Dropdown/Dropdown.test.jsx
+++ b/src/Dropdown/Dropdown.test.jsx
@@ -6,15 +6,14 @@ import { mount, shallow } from 'enzyme'
 
 import Dropdown from './Dropdown'
 import FormLabel from '../form/FormLabel'
-import MenuItem from '@material-ui/core/MenuItem'
 
 describe('<Dropdown />', () => {
   it('renders the children', () => {
     const wrapper = shallow(
       <Dropdown>
-        <MenuItem value='1'>one</MenuItem>
-        <MenuItem value='2'>two</MenuItem>
-        <MenuItem value='3'>two</MenuItem>
+        <option value='1'>one</option>
+        <option value='2'>two</option>
+        <option value='3'>two</option>
       </Dropdown>
     ).dive().find(Select)
     expect(wrapper.childAt(0).props().value).toBe('1')
@@ -25,7 +24,7 @@ describe('<Dropdown />', () => {
   it('passes props to the Select component', () => {
     const wrapper = shallow(
       <Dropdown value='foo'>
-        <MenuItem value='1'>one</MenuItem>
+        <option value='1'>one</option>
       </Dropdown>
     ).dive().find(Select)
     expect(wrapper.props().value).toBe('foo')
@@ -35,8 +34,8 @@ describe('<Dropdown />', () => {
     it('disables the form control', () => {
       const wrapper = shallow(
         <Dropdown disabled>
-          <MenuItem value='1'>one</MenuItem>
-          <MenuItem value='2'>two</MenuItem>
+          <option value='1'>one</option>
+          <option value='2'>two</option>
         </Dropdown>
       ).dive().find(FormControl)
       expect(wrapper.props().disabled).toBe(true)
@@ -47,7 +46,7 @@ describe('<Dropdown />', () => {
     it('renders a label', () => {
       const wrapper = shallow(
         <Dropdown label='lorem'>
-          <MenuItem value='1'>one</MenuItem>
+          <option value='1'>one</option>
         </Dropdown>
       ).dive().find(FormLabel)
       expect(wrapper.contains('lorem')).toBe(true)
@@ -56,7 +55,7 @@ describe('<Dropdown />', () => {
     it('sets the htmlFor prop', () => {
       const wrapper = shallow(
         <Dropdown id='foo' label='lorem'>
-          <MenuItem value='1'>one</MenuItem>
+          <option value='1'>one</option>
         </Dropdown>
       ).dive().find(FormLabel)
       expect(wrapper.props().htmlFor).toBe('foo')
@@ -67,7 +66,7 @@ describe('<Dropdown />', () => {
     it('renders helper text', () => {
       const wrapper = shallow(
         <Dropdown helperText='lorem'>
-          <MenuItem value='1'>one</MenuItem>
+          <option value='1'>one</option>
         </Dropdown>
       ).dive().find(FormHelperText)
       expect(wrapper.contains('lorem')).toBe(true)
@@ -76,7 +75,7 @@ describe('<Dropdown />', () => {
     it('sets the helper text ID', () => {
       const wrapper = shallow(
         <Dropdown helperText='lorem' id='foo'>
-          <MenuItem value='1'>one</MenuItem>
+          <option value='1'>one</option>
         </Dropdown>
       ).dive().find(FormHelperText)
       expect(wrapper.props().id).toBe('foo-helper-text')
@@ -89,12 +88,11 @@ describe('<Dropdown />', () => {
         const onChange = jest.fn()
         const wrapper = mount(
           <Dropdown value='' onChange={onChange}>
-            <MenuItem value='1'>one</MenuItem>
-            <MenuItem value='2'>two</MenuItem>
+            <option value='1'>one</option>
+            <option value='2'>two</option>
           </Dropdown>
         )
-        wrapper.find('[role="button"]').simulate('click')
-        wrapper.find(MenuItem).at(1).simulate('click')
+        wrapper.find('option').at(1).simulate('change', { target: { value: '1' } })
         expect(onChange).toHaveBeenCalled()
       })
     })
@@ -104,10 +102,10 @@ describe('<Dropdown />', () => {
         const onFocus = jest.fn()
         const wrapper = mount(
           <Dropdown value='' onFocus={onFocus}>
-            <MenuItem value='1'>one</MenuItem>
+            <option value='1'>one</option>
           </Dropdown>
         )
-        wrapper.find('div[role="button"]').simulate('focus')
+        wrapper.find('option').at(0).simulate('focus')
         expect(onFocus).toHaveBeenCalled()
       })
     })
@@ -117,10 +115,10 @@ describe('<Dropdown />', () => {
         const onBlur = jest.fn()
         const wrapper = mount(
           <Dropdown value='' onBlur={onBlur}>
-            <MenuItem value='1'>one</MenuItem>
+            <option value='1'>one</option>
           </Dropdown>
         )
-        wrapper.find('div[role="button"]').simulate('blur')
+        wrapper.find('option').at(0).simulate('blur')
         expect(onBlur).toHaveBeenCalled()
       })
     })

--- a/src/Dropdown/stories/events.jsx
+++ b/src/Dropdown/stories/events.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { action } from '@storybook/addon-actions'
 import { withDocs } from 'storybook-readme'
 
@@ -24,30 +24,34 @@ The \`<Dropdown>\` component accepts multiple events:
 
 <!-- STORY -->
 `
+function ExampleDropdown (props) {
+  const [value, setValue] = useState('1')
 
-class ExampleDropdown extends React.Component {
-  state = {
-    value: '1'
+  const { onChange, ...dropdownProps } = props
+
+  const dropdownChange = (event) => {
+    onChange()
+    setValue(event.target.value)
   }
 
-  render () {
-    return (
-      <Dropdown
-        value={this.state.value}
-        {...this.props}
-      >
-        <option value='1'>One</option>
-        <option value='2'>Two</option>
-        <option value='3'>Three</option>
-      </Dropdown>
-    )
-  }
+  return (
+    <Dropdown
+      value={value}
+      onChange={dropdownChange}
+      {...dropdownProps}
+    >
+      <option value='1'>One</option>
+      <option value='2'>Two</option>
+      <option value='3'>Three</option>
+    </Dropdown>
+  )
 }
 
 export default withDocs(md, () =>
   <GridLayout>
     <ExampleDropdown
       helperText='Event triggers'
+      label='Events'
       onChange={action('change')}
       onBlur={action('blur')}
       onFocus={action('focus')}

--- a/src/Dropdown/stories/events.jsx
+++ b/src/Dropdown/stories/events.jsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { withDocs } from 'storybook-readme'
 
 import { GridLayout } from '../../util'
-import { Dropdown, MenuItem } from '../../index'
+import { Dropdown } from '../../index'
 
 const md = `
 # States
@@ -36,9 +36,9 @@ class ExampleDropdown extends React.Component {
         value={this.state.value}
         {...this.props}
       >
-        <MenuItem value='1'>One</MenuItem>
-        <MenuItem value='2'>Two</MenuItem>
-        <MenuItem value='3'>Three</MenuItem>
+        <option value='1'>One</option>
+        <option value='2'>Two</option>
+        <option value='3'>Three</option>
       </Dropdown>
     )
   }

--- a/src/Dropdown/stories/index.jsx
+++ b/src/Dropdown/stories/index.jsx
@@ -3,8 +3,10 @@ import { storiesOf } from '@storybook/react'
 import overview from './overview'
 import events from './events'
 import states from './states'
+import variants from './variants'
 
 storiesOf('Dropdowns', module)
   .add('Overview', overview)
   .add('States', states)
   .add('Events', events)
+  .add('Variants', variants)

--- a/src/Dropdown/stories/states.jsx
+++ b/src/Dropdown/stories/states.jsx
@@ -3,7 +3,7 @@ import { action } from '@storybook/addon-actions'
 import { withDocs } from 'storybook-readme'
 
 import { GridLayout } from '../../util'
-import { Dropdown, MenuItem } from '../../index'
+import { Dropdown } from '../../index'
 
 const md = `
 # States
@@ -44,9 +44,9 @@ class ExampleDropdown extends React.Component {
         onChange={this.handleChange}
         value={this.state.value}
       >
-        <MenuItem value='1'>One</MenuItem>
-        <MenuItem value='2'>Two</MenuItem>
-        <MenuItem value='3'>Three</MenuItem>
+        <option value='1'>One</option>
+        <option value='2'>Two</option>
+        <option value='3'>Three</option>
       </Dropdown>
     )
   }

--- a/src/Dropdown/stories/variants.jsx
+++ b/src/Dropdown/stories/variants.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+import { withDocs } from 'storybook-readme'
+
+import { GridLayout } from '../../util'
+import { Dropdown, MenuItem } from '../../index'
+
+const md = `
+# Variants
+
+The \`<Dropdown>\` component allows users to select from a list of items,
+rendering MUI's native \`Select\` by default. Keep in mind that non-native
+\`Select\` components only allow \`MenuItem\` components as children, where
+the native implementation will receive HTML \`option\` tags as children.
+
+## Example
+
+<!-- STORY -->
+`
+
+function VariantsExample () {
+  const [value, setValue] = useState('1')
+
+  return (
+    <GridLayout>
+      <Dropdown
+        label='Native'
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      >
+        <option value='1'>One</option>
+        <option value='2'>Two</option>
+        <option value='3'>Three</option>
+      </Dropdown>
+
+      <Dropdown
+        label='MUI'
+        native={false}
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      >
+        <MenuItem value='1'>One</MenuItem>
+        <MenuItem value='2'>Two</MenuItem>
+        <MenuItem value='3'>Three</MenuItem>
+      </Dropdown>
+    </GridLayout>
+  )
+}
+
+export default withDocs(md, () => <VariantsExample />)


### PR DESCRIPTION
**Why?**

MUI custom select creates too much friction for users and test utilities. Let's use the native version instead.

If we want to use it anyway, we can disable the native version by passing the `<Dropdown native={false} />` prop.

**How to test  it?**

- Checkout this branch
- Run storybook (e.g.: `make storybook`)
- Read the new documentation on "Dropdown" overview (e.g.: http://localhost:9001/?path=/story/dropdowns--overview)
- See the native select in action checking the "Dropdown" "States" stories (e.g.: http://localhost:9001/?path=/story/dropdowns--states)

