### PR TITLE
Disentangle error prop and error state in Text Field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Fix bug introduced in 2.23.0 where `TextField` would appear to ignore changes to its `error` prop.
+
 # 2.26.0 (2020-12-07)
 
 * `Dropdown` component now renders MUI native `Select` component by default

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -76,11 +76,12 @@ export const TextField = ({
   maxLengthCountText,
   ...other
 }) => {
-  const [errorState, setErrorState] = useState(error)
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined
 
   // Max length validation with character count
   const [characterCount, setCharacterCount] = useState(0)
+  // This will be true if we're violating the length validation
+  const [excessChars, setExcessChars] = useState(false)
   const hasLengthValidation = maxLength > 0
   const maxValidationHelperText = `${characterCount}/${maxLength} ${maxLengthCountText}`
   const showHelperText = helperText || hasLengthValidation
@@ -110,7 +111,7 @@ export const TextField = ({
       const currentCharacterCount = event.target.value.length
 
       setCharacterCount(currentCharacterCount)
-      setErrorState(currentCharacterCount > maxLength)
+      setExcessChars(currentCharacterCount > maxLength)
     }
   }
 
@@ -122,8 +123,12 @@ export const TextField = ({
   // Separate MUI classes to pass to MUI
   const { formLabel, formHelperText, ...muiClasses } = classes
 
+  // We want to respect both `error` and `excessChars` when determining whether
+  // to show the component in an error state
+  const anyErrors = error || excessChars
+
   return (
-    <FormControl aria-describedby={helperTextId} disabled={disabled} error={errorState} fullWidth={fullWidth}>
+    <FormControl aria-describedby={helperTextId} disabled={disabled} error={anyErrors} fullWidth={fullWidth}>
       {label && (
         <FormLabel className={classes.formLabel} htmlFor={id} required={required}>
           {label}

--- a/src/TextField/stories/states.jsx
+++ b/src/TextField/stories/states.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
+import { boolean } from '@storybook/addon-knobs'
 import { withDocs } from 'storybook-readme'
 
 import { GridLayout } from '../../util'
@@ -29,30 +30,37 @@ You can set the state of a text field using one (or more) boolean flags:
 export default withDocs(md, () =>
   <GridLayout>
     <TextField
+      error={boolean('Error', false)}
       helperText='Helper text'
       label='Default'
       onChange={action('change')}
       placeholder='Placeholder text'
     />
-    <TextField required
+    <TextField
+      error={boolean('Error', false)}
       helperText='Helper text'
       label='Required'
       onChange={action('change')}
       placeholder='Placeholder text'
+      required
     />
-    <TextField disabled
+    <TextField
+      disabled
+      error={boolean('Error', false)}
       helperText='Helper text'
       label='Disabled'
       onChange={action('change')}
       placeholder='Placeholder text'
     />
-    <TextField error
+    <TextField
+      error
       helperText='Helper text'
       label='Error'
       onChange={action('change')}
       placeholder='Placeholder text'
     />
     <TextField
+      error={boolean('Error', false)}
       inputProps={{ style: { background: 'lightyellow' } }}
       helperText='Helper text'
       label='Custom'
@@ -60,6 +68,7 @@ export default withDocs(md, () =>
       placeholder='Placeholder text'
     />
     <TextField
+      error={boolean('Error', false)}
       helperText='Helper text'
       label='Maximum length validation'
       onChange={action('change')}


### PR DESCRIPTION
The root cause of https://trello.com/c/S2U0mYF9/5338-fix-error-text-colour-regression is the fact that https://github.com/conversation/ui/pull/136 made a separation between a `TextField`'s `error` prop, and the `errorState` state variable. TC-Donate is trying to make its inputs look like they have errors by setting the prop, but the state variable isn't changing, so the inputs keep their benign grey appearance.

This commit ensures the component always pays attention to the `error` prop whilst not breaking the char count functionality introduced in https://github.com/conversation/ui/pull/136 by considering both at the same time when determining whether to show the component in an error state. It makes `errorState` fully independent from the value of `error` and renames it to make it clearer what error it actually represents.

To see the new behaviour, I've introduced the `error` prop as a [Storybook knob](https://github.com/storybookjs/storybook/tree/master/addons/knobs).

- run the app storybook on this branch - `make storybook`
- go to the `TextField` States page - http://localhost:9001/?path=/story/text-fields--states
- note that only the error field is in an error state (red text, red border)
- toggle the Maximum length validation field between too many characters and not too many, noting that the error state is correct for each condition:

https://user-images.githubusercontent.com/157501/107906906-6bdf9080-6fa6-11eb-8668-1fb3007e8bac.mov

- set the `Error` knob to true:

https://user-images.githubusercontent.com/157501/107906921-73069e80-6fa6-11eb-9b9a-5752e0953279.mov

- note that all fields are now in an error condition 
- toggle the Maximum length validation field between too many characters and not too many, noting that the error state is _always on_ for each condition:

https://user-images.githubusercontent.com/157501/107906935-7a2dac80-6fa6-11eb-9aae-a53f39164591.mov

- ensure there are too many characters in the Maximum length validation field
- set the `Error` knob to false
- note that the Maximum length validation field returns to the correct error state depending on the number of characters:

https://user-images.githubusercontent.com/157501/107906950-831e7e00-6fa6-11eb-9a2f-a1a183e35627.mov

