### PR TITLE
Bump versions: material UI core (4.5.0 -> 4.5.2) and labs (4.0.0-alpha23 -> 4.0.0-alpha30)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1447,37 +1447,25 @@
       "dev": true
     },
     "@material-ui/core": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.5.0.tgz",
-      "integrity": "sha512-UHVAjU+1uDtA+OMBNBHb4RlCZOu514XeYPafNJv+GTdXBDr1SCPK7yqRE6TV1/bulxlDusTgu5Q6BAUgpmO4MA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.5.2.tgz",
+      "integrity": "sha512-yARw/hwavOXqljP+biDXHcmfbC63n8EkA8C10/tZt7KkBp7fs+7+z3BNR+ffotd8/uhirIC1jQWWKdLoUc34yA==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.5.0",
-        "@material-ui/system": "^4.5.0",
+        "@material-ui/styles": "^4.5.2",
+        "@material-ui/system": "^4.5.2",
         "@material-ui/types": "^4.1.1",
-        "@material-ui/utils": "^4.4.0",
+        "@material-ui/utils": "^4.5.2",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.2",
         "convert-css-length": "^2.0.1",
-        "deepmerge": "^4.0.0",
         "hoist-non-react-statics": "^3.2.1",
-        "is-plain-object": "^3.0.0",
         "normalize-scroll-left": "^0.2.0",
         "popper.js": "^1.14.1",
         "prop-types": "^15.7.2",
         "react-transition-group": "^4.3.0"
       },
       "dependencies": {
-        "@material-ui/utils": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0"
-          }
-        },
         "csstype": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
@@ -1493,19 +1481,14 @@
           },
           "dependencies": {
             "@babel/runtime": {
-              "version": "7.12.13",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-              "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+              "version": "7.12.18",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+              "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
               "requires": {
                 "regenerator-runtime": "^0.13.4"
               }
             }
           }
-        },
-        "is-plain-object": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-          "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g=="
         },
         "prop-types": {
           "version": "15.7.2",
@@ -1515,19 +1498,12 @@
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
             "react-is": "^16.8.1"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "16.13.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-              "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-            }
           }
         },
         "react-is": {
-          "version": "17.0.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "react-transition-group": {
           "version": "4.4.1",
@@ -1585,14 +1561,9 @@
           }
         },
         "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "warning": {
           "version": "4.0.3",
@@ -1676,29 +1647,12 @@
           "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
           "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
         },
-        "@material-ui/utils": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0"
-          }
-        },
         "hoist-non-react-statics": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
           "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
           "requires": {
             "react-is": "^16.7.0"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "16.13.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-              "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-            }
           }
         },
         "jss": {
@@ -1736,11 +1690,6 @@
               "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
             }
           }
-        },
-        "react-is": {
-          "version": "17.0.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
-          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
         }
       }
     },
@@ -1755,16 +1704,41 @@
         "prop-types": "^15.7.2"
       },
       "dependencies": {
-        "@material-ui/utils": {
-          "version": "4.11.2",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
-          "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "requires": {
-            "@babel/runtime": "^7.4.4",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0 || ^17.0.0"
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
           }
         },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        }
+      }
+    },
+    "@material-ui/types": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
+      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@material-ui/utils": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+      "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      },
+      "dependencies": {
         "prop-types": {
           "version": "15.7.2",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -1786,46 +1760,6 @@
           "version": "17.0.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
           "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA=="
-        }
-      }
-    },
-    "@material-ui/types": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-4.1.1.tgz",
-      "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
-      "requires": {
-        "@types/react": "*"
-      }
-    },
-    "@material-ui/utils": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.3.0.tgz",
-      "integrity": "sha512-tK3Z/ap5ifPQwIryuGQ+AHLh2hEyBLRPj4NCMcqVrQfD+0KH2IP5BXR4A+wGVsyamKfLaOc8tz1fzxZblsztpw==",
-      "requires": {
-        "@babel/runtime": "^7.4.4",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.6"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "react-is": {
-          "version": "16.9.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-          "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
-        },
-        "regenerator-runtime": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
         }
       }
     },
@@ -9843,9 +9777,9 @@
           },
           "dependencies": {
             "@babel/runtime": {
-              "version": "7.12.13",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.13.tgz",
-              "integrity": "sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==",
+              "version": "7.12.18",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+              "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
               "requires": {
                 "regenerator-runtime": "^0.13.4"
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1539,15 +1539,14 @@
       }
     },
     "@material-ui/lab": {
-      "version": "4.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.23.tgz",
-      "integrity": "sha512-XoYXyXpOP9bJwDbfxwQdJT00KlKuqxa7GeJLXXVMHa5Aots1sxldr+bGykf+f0TnfF3wwNgTCsMvq2SZgTTb3Q==",
+      "version": "4.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.30.tgz",
+      "integrity": "sha512-O+QQoYKy5o3z4CMd3rrbe5kSY4LAA5oPOFeum0JX4tMdV/frpAB86nGSNbs09cqunBtB0IplNBoKTla+NWLhqw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.1.0",
+        "@material-ui/utils": "^4.5.2",
         "clsx": "^1.0.4",
-        "prop-types": "^15.7.2",
-        "warning": "^4.0.3"
+        "prop-types": "^15.7.2"
       },
       "dependencies": {
         "prop-types": {
@@ -1564,14 +1563,6 @@
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        },
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@material-ui/core": "4.5.2",
     "@material-ui/icons": "4.2.1",
-    "@material-ui/lab": "4.0.0-alpha.23",
+    "@material-ui/lab": "4.0.0-alpha.30",
     "@material-ui/pickers": "3.2.2",
     "deepmerge": "4.0.0",
     "downshift": "3.2.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "git+ssh://git@github.com/conversation/ui.git"
   },
   "dependencies": {
-    "@material-ui/core": "4.5.0",
+    "@material-ui/core": "4.5.2",
     "@material-ui/icons": "4.2.1",
     "@material-ui/lab": "4.0.0-alpha.23",
     "@material-ui/pickers": "3.2.2",

--- a/src/styles/ThemeProvider.jsx
+++ b/src/styles/ThemeProvider.jsx
@@ -1,5 +1,5 @@
 import JssProvider from 'react-jss/lib/JssProvider'
-import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider'
+import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles'
 import PropTypes from 'prop-types'
 import React from 'react'
 


### PR DESCRIPTION
**Why?**

MUI introduced their [`Autocomplete` component](https://material-ui.com/components/autocomplete/) on version 4.5.2 and labs 4.0.0-alpha30.

We'll want to use that in the future, so let's update both packages.