### PR TITLE
Allow text fields and dropdowns labels to be React components

### DIFF
--- a/src/Dropdown/Dropdown.jsx
+++ b/src/Dropdown/Dropdown.jsx
@@ -141,7 +141,7 @@ Dropdown.propTypes = {
   /**
    * The text displayed above the dropdown.
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
 
   /**
    * Defines if the Dropdown will be rendered as native.

--- a/src/TextField/TextField.jsx
+++ b/src/TextField/TextField.jsx
@@ -197,7 +197,7 @@ TextField.propTypes = {
   /**
    * The text displayed above the text field.
    */
-  label: PropTypes.string,
+  label: PropTypes.node,
 
   /**
    * The callback function called when the text field value changes.


### PR DESCRIPTION
**Why?**

We want to be able to render React components on `TextField`s and `Dropdown`s labels without prop type validation errors.

Since both components render their labels using MUI `FormLabel` component, we can safely change its prop type to `node`, so it matches MUI `FormLabel` children prop type.

Documentation: https://v4-5-2.material-ui.com/api/form-label/#formlabel-api.