### PR TITLE
Ensure mui styles and core libs are the same version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1357,8 +1357,7 @@
     "@emotion/hash": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.1.tgz",
-      "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==",
-      "dev": true
+      "integrity": "sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA=="
     },
     "@emotion/is-prop-valid": {
       "version": "0.7.3",
@@ -1606,50 +1605,32 @@
       }
     },
     "@material-ui/styles": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.3.tgz",
-      "integrity": "sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.5.2.tgz",
+      "integrity": "sha512-QUqPk4tdPiDLs/1flB6qdAqUrYSxHv4YLCgvFeZw9A9OK/lf8LFjciF/SsSIDOCwoV2kf3BiGTzWUGjb/TTgzA==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@emotion/hash": "^0.8.0",
-        "@material-ui/types": "^5.1.0",
-        "@material-ui/utils": "^4.11.2",
-        "clsx": "^1.0.4",
+        "@emotion/hash": "^0.7.1",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.5.2",
+        "clsx": "^1.0.2",
         "csstype": "^2.5.2",
-        "hoist-non-react-statics": "^3.3.2",
-        "jss": "^10.5.1",
-        "jss-plugin-camel-case": "^10.5.1",
-        "jss-plugin-default-unit": "^10.5.1",
-        "jss-plugin-global": "^10.5.1",
-        "jss-plugin-nested": "^10.5.1",
-        "jss-plugin-props-sort": "^10.5.1",
-        "jss-plugin-rule-value-function": "^10.5.1",
-        "jss-plugin-vendor-prefixer": "^10.5.1",
+        "hoist-non-react-statics": "^3.2.1",
+        "jss": "^10.0.0",
+        "jss-plugin-camel-case": "^10.0.0",
+        "jss-plugin-default-unit": "^10.0.0",
+        "jss-plugin-global": "^10.0.0",
+        "jss-plugin-nested": "^10.0.0",
+        "jss-plugin-props-sort": "^10.0.0",
+        "jss-plugin-rule-value-function": "^10.0.0",
+        "jss-plugin-vendor-prefixer": "^10.0.0",
         "prop-types": "^15.7.2"
       },
       "dependencies": {
-        "@emotion/hash": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
-        },
-        "@material-ui/types": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-          "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
-        },
-        "hoist-non-react-statics": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
         "jss": {
-          "version": "10.5.1",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
-          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "csstype": "^3.0.2",
@@ -1659,9 +1640,9 @@
           },
           "dependencies": {
             "csstype": {
-              "version": "3.0.6",
-              "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-              "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+              "version": "3.0.7",
+              "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+              "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
             }
           }
         },
@@ -1673,14 +1654,12 @@
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
             "react-is": "^16.8.1"
-          },
-          "dependencies": {
-            "react-is": {
-              "version": "16.13.1",
-              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-              "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-            }
           }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -9616,19 +9595,19 @@
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.5.1.tgz",
-      "integrity": "sha512-9+oymA7wPtswm+zxVti1qiowC5q7bRdCJNORtns2JUj/QHp2QPXYwSNRD8+D2Cy3/CEMtdJzlNnt5aXmpS6NAg==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.6.0.tgz",
+      "integrity": "sha512-JdLpA3aI/npwj3nDMKk308pvnhoSzkW3PXlbgHAzfx0yHWnPPVUjPhXFtLJzgKZge8lsfkUxvYSQ3X2OYIFU6A==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.5.1"
+        "jss": "10.6.0"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
         },
         "hyphenate-style-name": {
           "version": "1.0.4",
@@ -9636,9 +9615,9 @@
           "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
         },
         "jss": {
-          "version": "10.5.1",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
-          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "csstype": "^3.0.2",
@@ -9650,23 +9629,23 @@
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.5.1.tgz",
-      "integrity": "sha512-D48hJBc9Tj3PusvlillHW8Fz0y/QqA7MNmTYDQaSB/7mTrCZjt7AVRROExoOHEtd2qIYKOYJW3Jc2agnvsXRlQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.6.0.tgz",
+      "integrity": "sha512-7y4cAScMHAxvslBK2JRK37ES9UT0YfTIXWgzUWD5euvR+JR3q+o8sQKzBw7GmkQRfZijrRJKNTiSt1PBsLI9/w==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.1"
+        "jss": "10.6.0"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
         },
         "jss": {
-          "version": "10.5.1",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
-          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "csstype": "^3.0.2",
@@ -9678,23 +9657,23 @@
       }
     },
     "jss-plugin-global": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.5.1.tgz",
-      "integrity": "sha512-jX4XpNgoaB8yPWw/gA1aPXJEoX0LNpvsROPvxlnYe+SE0JOhuvF7mA6dCkgpXBxfTWKJsno7cDSCgzHTocRjCQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.6.0.tgz",
+      "integrity": "sha512-I3w7ji/UXPi3VuWrTCbHG9rVCgB4yoBQLehGDTmsnDfXQb3r1l3WIdcO8JFp9m0YMmyy2CU7UOV6oPI7/Tmu+w==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.1"
+        "jss": "10.6.0"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
         },
         "jss": {
-          "version": "10.5.1",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
-          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "csstype": "^3.0.2",
@@ -9706,24 +9685,24 @@
       }
     },
     "jss-plugin-nested": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.5.1.tgz",
-      "integrity": "sha512-xXkWKOCljuwHNjSYcXrCxBnjd8eJp90KVFW1rlhvKKRXnEKVD6vdKXYezk2a89uKAHckSvBvBoDGsfZrldWqqQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.6.0.tgz",
+      "integrity": "sha512-fOFQWgd98H89E6aJSNkEh2fAXquC9aZcAVjSw4q4RoQ9gU++emg18encR4AT4OOIFl4lQwt5nEyBBRn9V1Rk8g==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.1",
+        "jss": "10.6.0",
         "tiny-warning": "^1.0.2"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
         },
         "jss": {
-          "version": "10.5.1",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
-          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "csstype": "^3.0.2",
@@ -9735,23 +9714,23 @@
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.5.1.tgz",
-      "integrity": "sha512-t+2vcevNmMg4U/jAuxlfjKt46D/jHzCPEjsjLRj/J56CvP7Iy03scsUP58Iw8mVnaV36xAUZH2CmAmAdo8994g==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.6.0.tgz",
+      "integrity": "sha512-oMCe7hgho2FllNc60d9VAfdtMrZPo9n1Iu6RNa+3p9n0Bkvnv/XX5San8fTPujrTBScPqv9mOE0nWVvIaohNuw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.1"
+        "jss": "10.6.0"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
         },
         "jss": {
-          "version": "10.5.1",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
-          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "csstype": "^3.0.2",
@@ -9763,24 +9742,24 @@
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.5.1.tgz",
-      "integrity": "sha512-3gjrSxsy4ka/lGQsTDY8oYYtkt2esBvQiceGBB4PykXxHoGRz14tbCK31Zc6DHEnIeqsjMUGbq+wEly5UViStQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.6.0.tgz",
+      "integrity": "sha512-TKFqhRTDHN1QrPTMYRlIQUOC2FFQb271+AbnetURKlGvRl/eWLswcgHQajwuxI464uZk91sPiTtdGi7r7XaWfA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.5.1",
+        "jss": "10.6.0",
         "tiny-warning": "^1.0.2"
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
         },
         "jss": {
-          "version": "10.5.1",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
-          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "csstype": "^3.0.2",
@@ -9792,13 +9771,13 @@
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.5.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.5.1.tgz",
-      "integrity": "sha512-cLkH6RaPZWHa1TqSfd2vszNNgxT1W0omlSjAd6hCFHp3KIocSrW21gaHjlMU26JpTHwkc+tJTCQOmE/O1A4FKQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.6.0.tgz",
+      "integrity": "sha512-doJ7MouBXT1lypLLctCwb4nJ6lDYqrTfVS3LtXgox42Xz0gXusXIIDboeh6UwnSmox90QpVnub7au8ybrb0krQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "css-vendor": "^2.0.8",
-        "jss": "10.5.1"
+        "jss": "10.6.0"
       },
       "dependencies": {
         "css-vendor": {
@@ -9811,9 +9790,9 @@
           },
           "dependencies": {
             "@babel/runtime": {
-              "version": "7.12.18",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-              "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+              "version": "7.13.10",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.13.10.tgz",
+              "integrity": "sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==",
               "requires": {
                 "regenerator-runtime": "^0.13.4"
               }
@@ -9821,14 +9800,14 @@
           }
         },
         "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.7.tgz",
+          "integrity": "sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g=="
         },
         "jss": {
-          "version": "10.5.1",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.5.1.tgz",
-          "integrity": "sha512-hbbO3+FOTqVdd7ZUoTiwpHzKXIo5vGpMNbuXH1a0wubRSWLWSBvwvaq4CiHH/U42CmjOnp6lVNNs/l+Z7ZdDmg==",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/jss/-/jss-10.6.0.tgz",
+          "integrity": "sha512-n7SHdCozmxnzYGXBHe0NsO0eUf9TvsHVq2MXvi4JmTn3x5raynodDVE/9VQmBdWFyyj9HpHZ2B4xNZ7MMy7lkw==",
           "requires": {
             "@babel/runtime": "^7.3.1",
             "csstype": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@material-ui/core": "4.5.2",
+    "@material-ui/styles": "4.5.2",
     "@material-ui/icons": "4.2.1",
     "@material-ui/lab": "4.0.0-alpha.30",
     "@material-ui/pickers": "3.2.2",


### PR DESCRIPTION
In TC there's a problem where we are ending up with slightly different versions of mui core and styles, which means that the
styles code is accessing properties in core which don't exist.

Easiest way to solve this is locking down the version number of styles so that it matches core, rather than just letting npm install random minor versions that are incompatible.

A bit hard to test because it involves code that hasn't/can't merge yet on TC but here's a before and after:

### Before
```
 FAIL  app/assets/javascripts/lib/renderReactWithStyles.spec.js
  ● Test suite failed to run
 
    TypeError: Cannot set property 'displayName' of undefined
 
      4 | import hypernova from "hypernova";
      5 | 
    > 6 | import { ServerStyleSheets } from "@material-ui/styles";
        | ^
      7 | 
      8 | // A custom renderer which extracts JSS required by the given
      9 | // React tree and includes it as a <style> tag alongside the
 
      at Object.<anonymous> (node_modules/@material-ui/styles/useTheme/ThemeContext.js:15:28)
      at Object.<anonymous> (node_modules/@material-ui/styles/useTheme/useTheme.js:12:44)
      at Object.<anonymous> (node_modules/@material-ui/styles/useTheme/index.js:15:40)
      at Object.<anonymous> (node_modules/@material-ui/styles/makeStyles/makeStyles.js:22:40)
      at Object.<anonymous> (node_modules/@material-ui/styles/makeStyles/index.js:15:42)
      at Object.<anonymous> (node_modules/@material-ui/styles/index.js:161:43)
      at Object.<anonymous> (app/assets/javascripts/lib/renderReactWithStyles.js:6:1)
      at Object.<anonymous> (app/assets/javascripts/lib/renderReactWithStyles.spec.js:1:1)
...

Test Suites: 1 failed, 145 passed, 146 total
Tests:       646 passed, 646 total
Snapshots:   1 passed, 1 total
Time:        17.931s
```


### After

```
Test Suites: 146 passed, 146 total
Tests:       648 passed, 648 total
Snapshots:   1 passed, 1 total
Time:        5.382s
```