### PR TITLE
Swap z-index values between tooltips and modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Decreased tooltip z-index value on all themes (tooltips will appear behind modals)
 * Remove `deepmerge` dependency
     * We're using MUI's `@material-ui/utils` implementation, added on https://github.com/mui-org/material-ui/pull/17982
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Remove `deepmerge` dependency
+    * We're using MUI's `@material-ui/utils` implementation, added on https://github.com/mui-org/material-ui/pull/17982
+
 # 2.32.0 (2021-05-14)
 
 * Export MUI `Tooltip` and `ClickAwayListener`

--- a/package-lock.json
+++ b/package-lock.json
@@ -5380,11 +5380,6 @@
       "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==",
       "dev": true
     },
-    "deepmerge": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.0.0.tgz",
-      "integrity": "sha512-YZ1rOP5+kHor4hMAH+HRQnBQHg+wvS1un1hAOuIcxcBy0hzcUf6Jg2a1w65kpoOUnurOfZbERwjI1TfZxNjcww=="
-    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,10 @@
   },
   "dependencies": {
     "@material-ui/core": "4.5.2",
-    "@material-ui/styles": "4.5.2",
     "@material-ui/icons": "4.2.1",
     "@material-ui/lab": "4.0.0-alpha.30",
     "@material-ui/pickers": "3.2.2",
-    "deepmerge": "4.0.0",
+    "@material-ui/styles": "4.5.2",
     "downshift": "3.2.7",
     "lodash": "4.17.21",
     "react-jss": "8.6.1"

--- a/src/styles/themes/accent.js
+++ b/src/styles/themes/accent.js
@@ -1,6 +1,7 @@
 import createMuiTheme from '@material-ui/core/styles/createMuiTheme'
 import memoize from 'lodash/memoize'
-import merge from 'deepmerge'
+import { deepmerge } from '@material-ui/utils'
+
 import accent from '../palettes/accent'
 import { typography, errorStateColours } from './common'
 
@@ -8,7 +9,7 @@ import { typography, errorStateColours } from './common'
  * This theme contains 'accent' coloured swatches
  */
 const theme = createMuiTheme(
-  merge(
+  deepmerge(
     {
       palette: {
         // mui colours

--- a/src/styles/themes/accent.js
+++ b/src/styles/themes/accent.js
@@ -3,7 +3,7 @@ import memoize from 'lodash/memoize'
 import { deepmerge } from '@material-ui/utils'
 
 import accent from '../palettes/accent'
-import { typography, errorStateColours } from './common'
+import { typography, errorStateColours, zIndex } from './common'
 
 /**
  * This theme contains 'accent' coloured swatches
@@ -16,7 +16,8 @@ const theme = createMuiTheme(
         primary: { main: accent[700] },
         secondary: { main: accent[600] }
       },
-      typography
+      typography,
+      zIndex
     }, errorStateColours
   )
 )

--- a/src/styles/themes/common.js
+++ b/src/styles/themes/common.js
@@ -23,3 +23,18 @@ export const errorStateColours = {
     error: { main: core[700], border: core[600] }
   }
 }
+
+// Our themes will consider that modals will always appear on top of tooltips.
+// We're bringing all z-index variable as the documentation discourages customizing
+// individual values.
+//
+// Documentation: https://v4-5-2.material-ui.com/customization/z-index/#z-index
+export const zIndex = {
+  mobileStepper: 1000,
+  speedDial: 1050,
+  appBar: 1100,
+  drawer: 1200,
+  tooltip: 1300,
+  modal: 1400,
+  snackbar: 1500
+}

--- a/src/styles/themes/core.js
+++ b/src/styles/themes/core.js
@@ -3,7 +3,7 @@ import memoize from 'lodash/memoize'
 import { deepmerge } from '@material-ui/utils'
 
 import core from '../palettes/core'
-import { typography, errorStateColours } from './common'
+import { typography, errorStateColours, zIndex } from './common'
 
 /**
  *  This theme contains 'core' coloured swatches
@@ -17,8 +17,10 @@ const theme = createMuiTheme(
         primary: { main: core[600] },
         secondary: { main: core[400] }
       },
-      typography
-    }, errorStateColours)
+      typography,
+      zIndex
+    }, errorStateColours
+  )
 )
 
 export default memoize(() => theme)

--- a/src/styles/themes/core.js
+++ b/src/styles/themes/core.js
@@ -1,14 +1,16 @@
 import createMuiTheme from '@material-ui/core/styles/createMuiTheme'
 import memoize from 'lodash/memoize'
-import merge from 'deepmerge'
-import { typography, errorStateColours } from './common'
+import { deepmerge } from '@material-ui/utils'
+
 import core from '../palettes/core'
+import { typography, errorStateColours } from './common'
+
 /**
  *  This theme contains 'core' coloured swatches
  */
 
 const theme = createMuiTheme(
-  merge(
+  deepmerge(
     {
       palette: {
       // mui colours

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -3,7 +3,7 @@ import memoize from 'lodash/memoize'
 import { deepmerge } from '@material-ui/utils'
 
 import neutral from '../palettes/neutral'
-import { typography, errorStateColours } from './common'
+import { typography, errorStateColours, zIndex } from './common'
 
 /**
  * This theme contains the styles which represent the future design of our
@@ -18,8 +18,10 @@ const theme = createMuiTheme(
         primary: { main: neutral[600] },
         secondary: { main: neutral[50] }
       },
-      typography
-    }, errorStateColours)
+      typography,
+      zIndex
+    }, errorStateColours
+  )
 )
 
 export default memoize(() => theme)

--- a/src/styles/themes/default.js
+++ b/src/styles/themes/default.js
@@ -1,9 +1,9 @@
 import createMuiTheme from '@material-ui/core/styles/createMuiTheme'
 import memoize from 'lodash/memoize'
-import merge from 'deepmerge'
-import { typography, errorStateColours } from './common'
+import { deepmerge } from '@material-ui/utils'
 
 import neutral from '../palettes/neutral'
+import { typography, errorStateColours } from './common'
 
 /**
  * This theme contains the styles which represent the future design of our
@@ -11,7 +11,7 @@ import neutral from '../palettes/neutral'
  */
 
 const theme = createMuiTheme(
-  merge(
+  deepmerge(
     {
       palette: {
       // mui colours


### PR DESCRIPTION
**Why?**

We're aiming to use tooltips on components that will show quick pieces of information of a certain entity while navigating through a page designed with this system.

On a page that mixes up absolute positioned components, such as dialog backdrops and tooltips, we want to ensure that modals are going to appear on top of tooltips.

**Screenshots**

- Before

![image](https://user-images.githubusercontent.com/1538066/120229887-86bbd500-c224-11eb-8875-5abf3417bdaa.png)

- After

![image](https://user-images.githubusercontent.com/1538066/120229890-88859880-c224-11eb-8a93-b956b69af5dd.png)
