### PR TITLE
Relax lodash dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@material-ui/pickers": "3.2.2",
     "@material-ui/styles": "4.5.2",
     "downshift": "3.2.7",
-    "lodash": "4.17.21",
+    "lodash": "^4.17.21",
     "react-jss": "8.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**Why?**

We don't want to force projects using this UI lib to have `lodash` version 4.17.21. Let's increase the version range to the patch version, using the caret syntax.