### PR TITLE
Add config to run storybook through Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM theconversation/node AS app
+
+# Add files required for storybook
+COPY package*.json /app/
+COPY babel.config.js /app/
+COPY src/ /app/
+
+# Install node modules
+RUN npm install --loglevel error

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ doc:
 storybook:
 	@npx start-storybook -p 9001 -c .storybook --ci
 
+storybook-docker:
+	@docker-compose up
+
 publish:
 	@npm publish
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ When working on components, you can run storybook locally:
 make storybook
 ```
 
+Alternatively, you can run storybook through Docker:
+
+```sh
+make storybook-docker
+```
+
 This will give you a hot reloading environment to rapidly develop in.
 
 If you want to test your newly developed components in a local app, the easiest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.7"
+
+services:
+  app:
+    command: "npx start-storybook -p 9001 -c .storybook --ci"
+    build:
+      context: .
+      target: app
+    volumes:
+      - .:/app
+      - node_modules:/app/node_modules
+    ports:
+      - "9001:9001"
+
+volumes:
+  node_modules:
+    name: ui-node-modules


### PR DESCRIPTION
@ZoeJazz would like to run storybook to be able to make changes to our UI components. However, there's currently no Docker config, which makes it quite complex to run for anyone without a machine-level node install. This PR adds a `make storybook-docker` task that spins up storybook inside docker.
