### PR TITLE
Use main as default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install: pip install --user awscli
 script: make lint test
 deploy:
   on:
-    branch: master
+    branch: main
     tags: true
   provider: script
   script: "cp .npmrc.template $HOME/.npmrc && make release"


### PR DESCRIPTION
We're renaming our 'master' branches to 'main', so we need to ensure build steps that targeted 'master' now run for 'main'.
