### PR TITLE
Make sure that the package is built before it is published

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,11 +7,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
+
       - run: npm install
+
+      - run: npm run build
+
+      - run: npx build-storybook -c .storybook -o doc
+
+      - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --delete --cache-control 'max-age=300'
+        env:
+          AWS_S3_BUCKET: 'styleguide.theconversation.com'
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'us-east-1'
+          SOURCE_DIR: 'doc'
+
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
There were a couple of issues with the new GitHub package workflow:

* We were publishing an empty package, this is because we forgot to build it first.
* We weren't uploading the storybook docs to S3

Both of these things have been addressed, and test packages have been built and deployed.

This also required creating a couple more organisation-level secrets for our AWS credentials (they are also in 1Password).