### PR TITLE
Use ubuntu node 16 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM theconversation/node AS app
+FROM theconversation/node-ubuntu:16.13.1
 
 # Add files required for storybook
 COPY package*.json /app/


### PR DESCRIPTION
We want all our docker images to use the same ubuntu base, so we should use that image here instead of the alpine one.

See:
* https://github.com/conversation/docs/blob/main/adr/20211006-use-ubuntu-20-04-for-base-docker-images.md
* https://github.com/conversation/docker-images/pull/19
