### PR TITLE
Remove storybook publication

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,18 +17,6 @@ jobs:
 
       - run: npm run build
 
-      - run: npx build-storybook -c .storybook -o doc
-
-      - uses: jakejarvis/s3-sync-action@master
-        with:
-          args: --acl public-read --delete --cache-control 'max-age=300'
-        env:
-          AWS_S3_BUCKET: 'styleguide.theconversation.com'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-east-1'
-          SOURCE_DIR: 'doc'
-
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We've deprecated this UI library and no longer want to make the storybook accessible, so this removes the actions to build and publish it.
