### PR TITLE
Upgrade MUI core to 4.10.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,3 +12,4 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm test
+      - run: bin/package_lock_lint.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .cache
 .node-version
+.vscode
 dist
 doc
 node_modules

--- a/bin/package_lock_lint.sh
+++ b/bin/package_lock_lint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+has_http=$(grep -c '"resolved": "http:' package-lock.json)
+
+# This is set after the grep above because we want to continue if it fails.
+#
+# -e causes an immediate exit when a command fails.
+#
+# -u treats unset variables as errors and causes an immediate exit.
+#
+# -o pipefail sets the exit code of a pipeline to the rightmost command that
+# exited with a non-zero status (or zero if none did) instead of the exit code
+# of the last command in a pipeline. e.g. `bad-command | echo "something ok"`
+# would exit 0 by default, -o pipefail changes it to exit 127.
+set -euo pipefail
+
+if [[ $has_http -gt 0 ]]
+then
+  echo "package-lock.json has resolved packages to HTTP addresses. They should be HTTPS."
+  echo "Try using 'sed -i '' -e 's/http:\/\//https:\/\//g' package-lock.json' to correct this."
+fi
+
+exit $has_http

--- a/package-lock.json
+++ b/package-lock.json
@@ -14646,9 +14646,9 @@
       "dev": true
     },
     "typeface-noto-sans": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/typeface-noto-sans/-/typeface-noto-sans-0.0.54.tgz",
-      "integrity": "sha512-wV2BNwFuSOYaz96gk5fDuD0RB4pPKKgQvvM9ep6jWRUTqPuND+fM4wz0xAqxopTYeZ/sVunyFIc3iCq7gMbULQ==",
+      "version": "0.0.72",
+      "resolved": "https://registry.npmjs.org/typeface-noto-sans/-/typeface-noto-sans-0.0.72.tgz",
+      "integrity": "sha512-a5wI6LUIQ/6XRRf9x/ZXjO4NwfTfcPmkMVe0SoUKVWw/s7GGWERAK73PKFLEmKKGaN59OkwFsotPgYtea0d34A==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3296,7 +3296,7 @@
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
       "dev": true
     },
@@ -4202,7 +4202,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -4239,7 +4239,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -4293,7 +4293,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -5075,7 +5075,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -5088,7 +5088,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -5342,7 +5342,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -5531,7 +5531,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -5676,7 +5676,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -7095,7 +7095,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -7591,7 +7591,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.5",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
@@ -7912,7 +7912,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -8221,7 +8221,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -10107,7 +10107,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -10298,7 +10298,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
@@ -10361,7 +10361,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -10370,7 +10370,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -12961,7 +12961,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -13153,7 +13153,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -13427,7 +13427,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -14044,7 +14044,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -14197,7 +14197,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -14325,7 +14325,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -15214,7 +15214,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14634,9 +14634,9 @@
       "dev": true
     },
     "typeface-libre-baskerville": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/typeface-libre-baskerville/-/typeface-libre-baskerville-0.0.54.tgz",
-      "integrity": "sha512-Irbz2y/QWJxoiJMdVxTK4zRKUZ2wdDVtf7c/mVO5lDgFLqnYnjaYh2/mTr/VuSsFnY8mK6A9mVp/QjB7XSYKpA==",
+      "version": "0.0.72",
+      "resolved": "https://registry.npmjs.org/typeface-libre-baskerville/-/typeface-libre-baskerville-0.0.72.tgz",
+      "integrity": "sha512-8eY5Tee80wNMfKCPYQguj2dODct+sQo3Et7meKOYklvaBRA1PK/DQnaNlYT+I85s1Z7PGUwBtZuG0yOIz4R9vg==",
       "dev": true
     },
     "typeface-montserrat": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1446,57 +1446,114 @@
       "dev": true
     },
     "@material-ui/core": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.5.2.tgz",
-      "integrity": "sha512-yARw/hwavOXqljP+biDXHcmfbC63n8EkA8C10/tZt7KkBp7fs+7+z3BNR+ffotd8/uhirIC1jQWWKdLoUc34yA==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.10.1.tgz",
+      "integrity": "sha512-bJb/07JFTht0oSjoWMu0j7r1mx4EbJ2ZHx+OKiY+i6IYW/4JPZ1J6rZuFS2b9jT+slSONPZaZq/kHitbE5lcig==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.5.2",
-        "@material-ui/system": "^4.5.2",
-        "@material-ui/types": "^4.1.1",
-        "@material-ui/utils": "^4.5.2",
+        "@material-ui/styles": "^4.10.0",
+        "@material-ui/system": "^4.9.14",
+        "@material-ui/types": "^5.1.0",
+        "@material-ui/utils": "^4.9.12",
         "@types/react-transition-group": "^4.2.0",
-        "clsx": "^1.0.2",
-        "convert-css-length": "^2.0.1",
-        "hoist-non-react-statics": "^3.2.1",
-        "normalize-scroll-left": "^0.2.0",
-        "popper.js": "^1.14.1",
+        "clsx": "^1.0.4",
+        "hoist-non-react-statics": "^3.3.2",
+        "popper.js": "1.16.1-lts",
         "prop-types": "^15.7.2",
-        "react-transition-group": "^4.3.0"
+        "react-is": "^16.8.0",
+        "react-transition-group": "^4.4.0"
       },
       "dependencies": {
-        "csstype": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+        "@emotion/hash": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+          "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+        },
+        "@material-ui/styles": {
+          "version": "4.11.5",
+          "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.5.tgz",
+          "integrity": "sha512-o/41ot5JJiUsIETME9wVLAJrmIWL3j0R0Bj2kCOLbSfqEkKf0fmaPt+5vtblUh5eXr2S+J/8J3DaCb10+CzPGA==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@emotion/hash": "^0.8.0",
+            "@material-ui/types": "5.1.0",
+            "@material-ui/utils": "^4.11.3",
+            "clsx": "^1.0.4",
+            "csstype": "^2.5.2",
+            "hoist-non-react-statics": "^3.3.2",
+            "jss": "^10.5.1",
+            "jss-plugin-camel-case": "^10.5.1",
+            "jss-plugin-default-unit": "^10.5.1",
+            "jss-plugin-global": "^10.5.1",
+            "jss-plugin-nested": "^10.5.1",
+            "jss-plugin-props-sort": "^10.5.1",
+            "jss-plugin-rule-value-function": "^10.5.1",
+            "jss-plugin-vendor-prefixer": "^10.5.1",
+            "prop-types": "^15.7.2"
+          },
+          "dependencies": {
+            "@material-ui/utils": {
+              "version": "4.11.3",
+              "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
+              "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
+              "requires": {
+                "@babel/runtime": "^7.4.4",
+                "prop-types": "^15.7.2",
+                "react-is": "^16.8.0 || ^17.0.0"
+              }
+            }
+          }
+        },
+        "@material-ui/types": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+          "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
         },
         "dom-helpers": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
-          "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+          "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
           "requires": {
             "@babel/runtime": "^7.8.7",
             "csstype": "^3.0.2"
           },
           "dependencies": {
             "@babel/runtime": {
-              "version": "7.12.18",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
-              "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
+              "version": "7.17.8",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
+              "integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
               "requires": {
                 "regenerator-runtime": "^0.13.4"
               }
+            },
+            "csstype": {
+              "version": "3.0.11",
+              "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+              "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
             }
           }
         },
+        "hoist-non-react-statics": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+          "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
+        "popper.js": {
+          "version": "1.16.1-lts",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+          "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
+        },
         "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "react-is": "^16.13.1"
           }
         },
         "react-is": {
@@ -1505,9 +1562,9 @@
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "react-transition-group": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
-          "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+          "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
           "requires": {
             "@babel/runtime": "^7.5.5",
             "dom-helpers": "^5.0.1",
@@ -1516,9 +1573,9 @@
           }
         },
         "regenerator-runtime": {
-          "version": "0.13.7",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-          "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+          "version": "0.13.9",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
         }
       }
     },
@@ -1664,30 +1721,47 @@
       }
     },
     "@material-ui/system": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.11.3.tgz",
-      "integrity": "sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.2.tgz",
+      "integrity": "sha512-6CSKu2MtmiJgcCGf6nBQpM8fLkuB9F55EKfbdTC80NND5wpTmKzwdhLYLH3zL4cLlK0gVaaltW7/wMuyTnN0Lw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/utils": "^4.11.2",
+        "@material-ui/utils": "^4.11.3",
         "csstype": "^2.5.2",
         "prop-types": "^15.7.2"
       },
       "dependencies": {
+        "@material-ui/utils": {
+          "version": "4.11.3",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.3.tgz",
+          "integrity": "sha512-ZuQPV4rBK/V1j2dIkSSEcH5uT6AaHuKWFfotADHsC0wVL1NLd2WkFCm4ZZbX33iO4ydl6V0GPngKm8HZQ2oujg==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "prop-types": "^15.7.2",
+            "react-is": "^16.8.0 || ^17.0.0"
+          }
+        },
         "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "version": "15.8.1",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+          "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
           "requires": {
             "loose-envify": "^1.4.0",
             "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
+            "react-is": "^16.13.1"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "16.13.1",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+              "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+            }
           }
         },
         "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
         }
       }
     },
@@ -2333,9 +2407,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
-      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
+      "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
       "requires": {
         "@types/react": "*"
       }
@@ -4930,11 +5004,6 @@
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
-    },
-    "convert-css-length": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.1.tgz",
-      "integrity": "sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg=="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -9522,6 +9591,24 @@
         "verror": "1.10.0"
       }
     },
+    "jss": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.9.0.tgz",
+      "integrity": "sha512-YpzpreB6kUunQBbrlArlsMpXYyndt9JATbt95tajx0t4MTJJcCJdd4hdNpHmOIDiUJrF/oX5wtVFrS3uofWfGw==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "csstype": "^3.0.2",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+          "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
+        }
+      }
+    },
     "jss-plugin-camel-case": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.6.0.tgz",
@@ -10648,11 +10735,6 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
-    "normalize-scroll-left": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.1.tgz",
-      "integrity": "sha512-YanMJCtsykxVQuWiwQR531bbyPtMt/jpUKy2XcVVe/oHiDgYme0NmuEZfceLeZhFbrQtO/GS/9KvWbSfDGRblA=="
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -11328,7 +11410,8 @@
     "popper.js": {
       "version": "1.14.7",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
-      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ==",
+      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-dom": "^16.8.6",
     "standard": "^12.0.1",
     "storybook-readme": "^4.0.5",
-    "typeface-libre-baskerville": "0.0.54",
+    "typeface-libre-baskerville": "0.0.72",
     "typeface-montserrat": "0.0.54",
     "typeface-noto-sans": "0.0.54"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "url": "git+ssh://git@github.com/conversation/ui.git"
   },
   "dependencies": {
-    "@material-ui/core": "4.5.2",
+    "@material-ui/core": "4.10.1",
     "@material-ui/icons": "4.2.1",
     "@material-ui/lab": "4.0.0-alpha.30",
     "@material-ui/pickers": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "storybook-readme": "^4.0.5",
     "typeface-libre-baskerville": "0.0.72",
     "typeface-montserrat": "0.0.54",
-    "typeface-noto-sans": "0.0.54"
+    "typeface-noto-sans": "0.0.72"
   },
   "peerDependencies": {
     "prop-types": "^15.6.2",


### PR DESCRIPTION
The [revised](https://conversation.slack.com/archives/C024N6U4QP7/p1648792330600059) [design](https://www.figma.com/file/qUZyvb3qPKiOK2lOGGoXhw/Donations---Gift-Aid?node-id=0%3A1) for Donations' Gift Aid inputs involves a tooltip with an arrow. The arrow feature MUI's `Tooltip` component arrived in [version 4.7.0](https://github.com/mui/material-ui/blob/HEAD/CHANGELOG.old.md#470) and received its final bugfix for the major version we currently use (v4) in [version 4.10.1](https://github.com/mui/material-ui/blob/HEAD/CHANGELOG.old.md#4101).

n.b. version 4.12.0 [deprecates `createMuiTheme`](https://github.com/mui/material-ui/blob/HEAD/CHANGELOG.old.md#material-uicore4120), which is a [breaking change](https://github.com/conversation/ui/runs/5845381547?check_suite_focus=true#logs) for us, so we'll need to stop at version 4.10.1.

**Testing**

- Checkout this branch
- Run `npm install`
- Run `make storybook`
- Check the Storybook at http://localhost:9001 to see if there have been any regressions
