### PR TITLE
Use node 16.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-docker.pkg.dev/tc-platform-artifacts/theconversation/node:16.14.2
+FROM us-docker.pkg.dev/tc-platform-artifacts/theconversation/node:16.15.0
 
 # Add files required for storybook
 COPY package*.json /app/


### PR DESCRIPTION
This upgrade is mostly for consistency with other apps, which upgraded as part of addressing an issue installing node from nodesource while building development docker images.

See:
* https://github.com/conversation/docker-images/pull/31
* https://github.com/nodejs/node/blob/v16.15.0/doc/changelogs/CHANGELOG_V16.md
