### PR TITLE
Allow whitespace in typeography component

### DIFF
--- a/src/Typography/Typography.jsx
+++ b/src/Typography/Typography.jsx
@@ -88,7 +88,8 @@ const styles = theme => ({
     fontSize: '1rem',
     [theme.breakpoints.up('sm')]: {
       fontSize: '1.125rem'
-    }
+    },
+    whiteSpace: 'pre-line'
   },
 
   body2: {
@@ -97,7 +98,8 @@ const styles = theme => ({
     fontSize: '1.125rem',
     [theme.breakpoints.up('sm')]: {
       fontSize: '1.5rem'
-    }
+    },
+    whiteSpace: 'pre-line'
   },
 
   button: {

--- a/src/Typography/stories/variants.jsx
+++ b/src/Typography/stories/variants.jsx
@@ -4,7 +4,7 @@ import { withDocs } from 'storybook-readme'
 import { Typography } from '../../index'
 
 const VARIANTS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2', 'button', 'caption', 'overline', 'inherit']
-const LIPSUM = 'Lorem ipsum'
+const LIPSUM = 'Lorem ipsum\ndolor'
 
 const md = `
 # Variants


### PR DESCRIPTION
This PR allows preserving newline characters in the `Typeography` component. It only applies to the `body1` and `body2` variants.

![image](https://github.com/conversation/ui/assets/3614/fd77a2e9-1afd-48b6-a6a7-6ba553050ef7)
