### PR TITLE
Upgrade to Node 16.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM us-docker.pkg.dev/tc-platform-artifacts/theconversation/node:16.15.0
+FROM us-docker.pkg.dev/tc-platform-artifacts/theconversation/node:16.20.1
 
 # Add files required for storybook
 COPY package*.json /app/


### PR DESCRIPTION
See:
* https://github.com/conversation/docker-images/pull/42
* https://nodejs.org/en/blog/vulnerability/june-2023-security-releases
* https://nodejs.org/en/blog/release/v16.20.1
