### PR TITLE
Create square-mono-for-bimi.svg

### DIFF
--- a/src/logos/square-mono-for-bimi.svg
+++ b/src/logos/square-mono-for-bimi.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.2" baseProfile="tiny" id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 158.74 158.74">
+xml:space="<title>The Conversation</title>
+<defs>
+<style>.cls-1{fill:#231f20;}.cls-2{fill:#fff;fill-rule:evenodd;}</style>
+</defs>
+<rect class="cls-1" width="158.74" height="158.74"/><path class="cls-2" d="m91.65,39.46h-24.56c-20.35,0-36.84,16.49-36.84,36.84,0,11,4.85,20.85,12.49,27.6l-8.19,19.28,20.25-12.19c3.85,1.36,7.97,2.14,12.28,2.14h24.56c20.35,0,36.84-16.49,36.84-36.84s-16.49-36.84-36.84-36.84Zm0,60.03h-24.56c-12.81,0-23.19-10.38-23.19-23.19s10.38-23.19,23.19-23.19h24.56c12.81,0,23.19,10.38,23.19,23.19s-10.38,23.19-23.19,23.19Z"/>
+</svg>


### PR DESCRIPTION
The BIMI standard requires a very specific SVG format for logo files. Zoë created the image with the relevant specs and I edited the SVG header per Google's advices here: https://support.google.com/a/answer/10911027